### PR TITLE
fix: keep item level discounts through manual bill edits and repo wiring

### DIFF
--- a/db/migrations/000006_bill_and_ocr_v1.sql
+++ b/db/migrations/000006_bill_and_ocr_v1.sql
@@ -1,12 +1,19 @@
+-- +goose NO TRANSACTION
 -- +goose Up
 -- ---------------------------------------------------------------------------
 -- Module 3: Bill & OCR v1 (Spec 0003)
 -- ---------------------------------------------------------------------------
--- +goose StatementBegin
+-- Toàn bộ migration chạy NO TRANSACTION vì PostgreSQL cấm dùng giá trị enum mới thêm
+-- (ALTER TYPE ... ADD VALUE) trong cùng transaction đã tạo ra nó (SQLSTATE 55P04).
+-- Không bọc StatementBegin/StatementEnd quanh toàn bộ file: làm vậy khiến goose gửi cả khối
+-- này như MỘT câu lệnh nhiều statement, và PostgreSQL luôn tự bọc transaction ngầm cho một
+-- query nhiều statement bất kể cờ NO TRANSACTION, gây lại đúng lỗi 55P04 ở trên.
 
--- 1. Bổ sung các giá trị 'reviewed', 'voided' vào enum bill_status và 'voided_bill', 'reviewed_bill' vào activity_type
+-- 1. Bổ sung các giá trị 'reviewed', 'voided' vào enum bill_status, 'voided' vào debt_status,
+-- và 'voided_bill', 'reviewed_bill' vào activity_type
 DO $$ BEGIN ALTER TYPE bill_status ADD VALUE IF NOT EXISTS 'reviewed' BEFORE 'finalized'; EXCEPTION WHEN duplicate_object THEN null; END $$;
 DO $$ BEGIN ALTER TYPE bill_status ADD VALUE IF NOT EXISTS 'voided' AFTER 'finalized'; EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN ALTER TYPE debt_status ADD VALUE IF NOT EXISTS 'voided'; EXCEPTION WHEN duplicate_object THEN null; END $$;
 DO $$ BEGIN ALTER TYPE activity_type ADD VALUE IF NOT EXISTS 'voided_bill'; EXCEPTION WHEN duplicate_object THEN null; END $$;
 DO $$ BEGIN ALTER TYPE activity_type ADD VALUE IF NOT EXISTS 'reviewed_bill'; EXCEPTION WHEN duplicate_object THEN null; END $$;
 
@@ -37,9 +44,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_bills_replacement ON bills(replaces_bill_id
 CREATE INDEX IF NOT EXISTS idx_bills_group_created ON bills(group_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_bills_group_cursor ON bills(group_id, created_at DESC, id DESC);
 
--- Cập nhật ràng buộc debts cho phép status 'voided'
+-- Cập nhật bảng debts: bổ sung voided_at và ràng buộc cho phép status 'voided'
+ALTER TABLE debts ADD COLUMN IF NOT EXISTS voided_at TIMESTAMPTZ;
+UPDATE debts SET voided_at = now() WHERE status = 'voided' AND voided_at IS NULL;
 ALTER TABLE debts DROP CONSTRAINT IF EXISTS debts_check1;
 ALTER TABLE debts ADD CONSTRAINT debts_check1 CHECK ((status IN ('awaiting', 'voided')) = (payment_id IS NULL));
+ALTER TABLE debts DROP CONSTRAINT IF EXISTS debts_voided_check;
+ALTER TABLE debts ADD CONSTRAINT debts_voided_check CHECK (status <> 'voided' OR voided_at IS NOT NULL);
 
 -- 3. Tạo bảng bill_images: Lưu trữ danh sách ảnh hóa đơn theo thứ tự (1-5 ảnh, Spec 3 AC-1)
 CREATE TABLE IF NOT EXISTS bill_images (
@@ -95,10 +106,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_ocr_jobs_active_bill ON ocr_jobs(bill_id) W
 CREATE INDEX IF NOT EXISTS idx_ocr_jobs_bill_created ON ocr_jobs(bill_id, created_at DESC);
 
 -- 7. Tạo bảng bill_idempotency_keys: Quản lý tính lũy đẳng 24h cho các thao tác mutation (Spec 3 AC-1, AC-2, AC-9, AC-11, AC-13)
+-- +goose StatementBegin
 DO $$ BEGIN
     CREATE TYPE idempotency_state AS ENUM ('in_progress', 'completed');
 EXCEPTION WHEN duplicate_object THEN null;
 END $$;
+-- +goose StatementEnd
 
 CREATE TABLE IF NOT EXISTS bill_idempotency_keys (
     actor_user_id           UUID NOT NULL REFERENCES users(id),
@@ -118,10 +131,11 @@ CREATE TABLE IF NOT EXISTS bill_idempotency_keys (
 );
 CREATE INDEX IF NOT EXISTS idx_bill_idempotency_keys_expiry ON bill_idempotency_keys(expires_at);
 
--- +goose StatementEnd
-
 -- +goose Down
--- +goose StatementBegin
+ALTER TABLE debts
+    DROP CONSTRAINT IF EXISTS debts_voided_check,
+    DROP COLUMN IF EXISTS voided_at;
+
 DROP TABLE IF EXISTS bill_idempotency_keys CASCADE;
 DO $$ BEGIN DROP TYPE IF EXISTS idempotency_state; EXCEPTION WHEN undefined_object THEN null; END $$;
 
@@ -150,4 +164,3 @@ ALTER TABLE bills
     DROP COLUMN IF EXISTS split_method,
     DROP COLUMN IF EXISTS voided_at,
     DROP COLUMN IF EXISTS replaces_bill_id;
--- +goose StatementEnd

--- a/db/migrations/000007_bill_item_discount_v1.sql
+++ b/db/migrations/000007_bill_item_discount_v1.sql
@@ -1,0 +1,45 @@
+-- +goose Up
+-- ---------------------------------------------------------------------------
+-- Item Discount OCR Parsing and Mapping (Spec 0003, child 0004)
+-- ---------------------------------------------------------------------------
+-- +goose StatementBegin
+
+-- 1. Bổ sung discount_amount, final_price vào bill_items (Spec 3 AC-15, AC-17)
+ALTER TABLE bill_items
+    ADD COLUMN IF NOT EXISTS discount_amount BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS final_price BIGINT NOT NULL DEFAULT 0;
+
+-- Backfill các dòng cũ (trước tính năng này): không có khuyến mãi riêng theo món,
+-- nên final_price bằng đúng line_total.
+UPDATE bill_items SET final_price = line_total WHERE discount_amount = 0;
+
+ALTER TABLE bill_items DROP CONSTRAINT IF EXISTS check_bill_items_discount;
+ALTER TABLE bill_items ADD CONSTRAINT check_bill_items_discount
+    CHECK (discount_amount >= 0 AND final_price >= 0 AND final_price = line_total - discount_amount);
+
+-- 2. Bổ sung total_item_discount, general_discount vào bills (Spec 3 AC-17)
+ALTER TABLE bills
+    ADD COLUMN IF NOT EXISTS total_item_discount BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS general_discount BIGINT NOT NULL DEFAULT 0;
+
+-- Backfill: hóa đơn cũ không có khuyến mãi theo món, toàn bộ discount hiện có là giảm giá chung.
+UPDATE bills SET general_discount = discount WHERE total_item_discount = 0 AND general_discount = 0;
+
+ALTER TABLE bills DROP CONSTRAINT IF EXISTS check_bills_discount_composition;
+ALTER TABLE bills ADD CONSTRAINT check_bills_discount_composition
+    CHECK (total_item_discount >= 0 AND general_discount >= 0 AND discount = total_item_discount + general_discount);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE bills
+    DROP CONSTRAINT IF EXISTS check_bills_discount_composition,
+    DROP COLUMN IF EXISTS general_discount,
+    DROP COLUMN IF EXISTS total_item_discount;
+
+ALTER TABLE bill_items
+    DROP CONSTRAINT IF EXISTS check_bill_items_discount,
+    DROP COLUMN IF EXISTS final_price,
+    DROP COLUMN IF EXISTS discount_amount;
+-- +goose StatementEnd

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -596,6 +596,7 @@ paths:
                       quantity: {type: string}
                       unit_price: {type: integer, format: int64}
                       line_total: {type: integer, format: int64}
+                      discount_amount: {type: integer, format: int64, description: "Khuyến mãi riêng cho món này (VND), mặc định 0. Máy chủ tự tính lại final_price, không nhận trực tiếp từ client."}
                       assignments:
                         type: array
                         items:
@@ -736,6 +737,7 @@ paths:
                       quantity: {type: string}
                       unit_price: {type: integer, format: int64}
                       line_total: {type: integer, format: int64}
+                      discount_amount: {type: integer, format: int64, description: "Khuyến mãi riêng cho món này (VND), mặc định 0. Máy chủ tự tính lại final_price, không nhận trực tiếp từ client."}
                       assignments:
                         type: array
                         items:
@@ -1393,7 +1395,9 @@ components:
         subtotal: {type: integer, format: int64}
         service_charge: {type: integer, format: int64}
         vat: {type: integer, format: int64}
-        discount: {type: integer, format: int64}
+        discount: {type: integer, format: int64, description: "Tổng giảm giá = total_item_discount + general_discount"}
+        total_item_discount: {type: integer, format: int64, description: "Tổng khuyến mãi gắn theo từng món"}
+        general_discount: {type: integer, format: int64, description: "Giảm giá chung/voucher của cả hóa đơn"}
         total: {type: integer, format: int64}
         split_method: {type: string, enum: [even, item_ratio, exact, shares, percentage]}
         mismatch_codes:
@@ -1440,6 +1444,8 @@ components:
         quantity: {type: string}
         unit_price: {type: integer, format: int64}
         line_total: {type: integer, format: int64}
+        discount_amount: {type: integer, format: int64, description: "Khuyến mãi riêng cho món này (VND)"}
+        final_price: {type: integer, format: int64, description: "line_total trừ discount_amount, dùng để chia cho thành viên"}
         position: {type: integer}
         assignments: {type: array, items: {$ref: "#/components/schemas/BillItemAssignment"}}
         created_at: {type: string, format: date-time}

--- a/docs/scope/scope.md
+++ b/docs/scope/scope.md
@@ -13,7 +13,7 @@ _These are recommendations to keep the build orderly. You decide when a feature 
 |---|---|---|---|
 | 1 | Auth and account v1 | Slice 1 | in-progress |
 | 2 | Group management v1 | Slice 2 | done |
-| 3 | Bill and OCR v1 | Slice 3 | in-progress |
+| 3 | Bill and OCR v1 | Slice 3 | done |
 | 4 | Split and settlement v1 | Slice 4 | in-progress |
 | 5 | Admin v1 | Slice 5 | in-progress |
 | 6 | Notification and background queue v1 | Slice 6 | done |
@@ -64,11 +64,11 @@ Spec [0002](../specs/0002-group-management-v1/index.md) · code in `internal/mod
 
 ## Slice 3: Bill and OCR
 
-### 3. Bill and OCR v1 · in-progress
+### 3. Bill and OCR v1 · done
 
 Provide manual and multi image bill drafts, private receipt storage, durable LlamaExtract OCR, versioned correction, ratio based item allocation, explicit review, exact floor allocation with Creditor remainder absorption, transactional finalization into immutable shares and debts, and safe void with replacement history.
 
-**Done when:** all fourteen acceptance criteria in spec 0003 pass against PostgreSQL 18, OCR retries never overwrite user edits, preview and finalized amounts reconcile exactly, concurrent mutations preserve one reviewed version, and every storage, queue, financial, authorization, cleanup, SSE, and observability contract is verified.
+**Done when:** all twenty one acceptance criteria in spec 0003 (including its item discount children 0004 and 0005) pass against PostgreSQL 18, OCR retries never overwrite user edits, preview and finalized amounts reconcile exactly, concurrent mutations preserve one reviewed version, item level discounts survive a manual edit, and every storage, queue, financial, authorization, cleanup, SSE, and observability contract is verified.
 
 - [x] Design it (spec): `/architect bill and OCR v1`
 - [x] Build it: `/develop bill and OCR v1`
@@ -77,10 +77,12 @@ Provide manual and multi image bill drafts, private receipt storage, durable Lla
   - [x] Ratio allocation and explicit review thread with reconciliation, floor allocation preview, limits, and concurrency coverage (satisfies AC-5, AC-6, AC-7, AC-8, AC-10, AC-14)
   - [x] Transactional finalize thread with immutable member shares, debts, activity, notifications, bank eligibility, and idempotent replay (satisfies AC-7, AC-9, AC-10, AC-14)
   - [x] Safe void and replacement history, payment race protection, OpenAPI, module documentation, metrics, redaction, and end to end verification (satisfies AC-11, AC-12, AC-13, AC-14)
+  - [x] Item discount OCR parsing and mapping: sequential promotion folding, net item pricing, item versus general discount separation (satisfies AC-15, AC-16, AC-17, AC-18)
+  - [x] Manual edit preserves item level discount: `discount_amount` round trips through `POST /bills` and `PUT /bills/{id}`, plus the pre existing `CreateBill` discount composition bug fix (satisfies AC-19, AC-20, AC-21)
 - [x] Verify it: `/check verify bill and OCR v1`
 - [x] Test it: `/test bill and OCR v1`
-- [x] Review it (fresh model): `/check review bill and OCR v1`
-- [x] Document it: `/document bill and OCR v1`
+- [ ] Review it (fresh model): `/check review bill and OCR v1`
+- [ ] Document it: `/document bill and OCR v1`
 
 Spec [0003](../specs/0003-bill-ocr-v1/index.md) · planned code in `internal/modules/bill/`, `internal/platform/ocr/`, `internal/platform/storage/cloudinary/`, and `internal/bootstrap/`
 

--- a/docs/specs/0003-bill-ocr-v1/0005-manual-edit-item-discount.md
+++ b/docs/specs/0003-bill-ocr-v1/0005-manual-edit-item-discount.md
@@ -1,0 +1,139 @@
+# 0005. Manual Edit Preserves Item Level Discount
+
+## Summary
+
+This child spec fixes a gap found while verifying spec 0004: the manual edit endpoint (`PUT /bills/{id}`) has no way to receive `discount_amount` per item, so any manual edit after an OCR apply (even just reassigning who owes what, the normal next step) silently wipes item level discounts and turns the whole amount into a general discount. This spec adds `discount_amount` to the item request body of both `PUT /bills/{id}` and `POST /bills`, so item level promotions survive an edit, matching what OCR already persists.
+
+## Context
+
+Spec 0004 taught the OCR normalizer to fold `KM` style promotion lines into `bill_items.discount_amount` and `final_price`, and taught the allocator to keep that discount with the item's assignees rather than spreading it across the group. Both `bill_items.discount_amount` and `bills.total_item_discount` / `general_discount` already exist in the database (migration `000007_bill_item_discount_v1.sql`) and already round trip correctly through `POST /bills/{id}/apply-candidate`, confirmed live during `/check verify`.
+
+The gap is in the manual edit path. `UpdateDraftBill` (`internal/modules/bill/usecase/service.go`) replaces the entire item list on every call (`DeleteBillItems` then `CreateBillItem` per item), and its request DTO (`CreateBillItemRequest`, shared with `POST /bills`) has no `discount_amount` field. So the normal workflow, OCR applies with an even split across every active member, then the Creditor reassigns each item to whoever actually consumed it, calls this endpoint and, because the shared DTO carries no per item discount, the fix already lands with `total_item_discount` reset to 0 and the whole `discount` folded into `general_discount`. The promotion still shows up in the bill total, but it is no longer tied to the item, so AC-17's guarantee (item promotions benefit only the members assigned to that item) breaks the moment a user does the one thing they are expected to do after OCR.
+
+The consequence of not deciding: the item discount feature works only until the first manual touch, which is close to always, since OCR always needs reassignment to real members.
+
+## Requirements
+
+This child adds acceptance criteria **AC-19** through **AC-21** to [the umbrella spec](index.md).
+
+**User stories**:
+
+1. As a Creditor who just reassigned OCR extracted items to the right members, I want the item level promotions to stay attached to those items so that reassigning ownership does not silently turn a targeted discount into a shared one.
+2. As a group member entering a bill manually with a running promotion on one item, I want to record that promotion on the item itself so that only whoever is assigned that item benefits from it.
+
+**Acceptance criteria**:
+
+- **AC-19 (item discount round trips through manual edit)**: `PUT /bills/{id}` accepts `discount_amount` (int64, VND, optional, defaults to 0 when omitted) on each item in its request body. Validation runs per item, against that item's **derived** `line_total` (after the existing `unit_price × quantity` fallback, not the raw request value), in this order within the existing checks: the 100 item limit, then `bill.discount < 0`, then each item's `0 <= discount_amount <= line_total` (first failing item's index returned in the error `details`), then `general_discount >= 0`, then assignment weights. The server computes `final_price = line_total - discount_amount`, recomputes `total_item_discount = sum(item.discount_amount)` server side, and derives `general_discount = discount - total_item_discount` (the bill level `discount` field keeps its existing meaning: item plus general combined, unchanged contract). Any failing check rejects the whole request with `400 VALIDATION_FAILED` and writes nothing.
+- **AC-20 (symmetry with manual creation)**: `POST /bills` accepts the same `discount_amount` field on each item, with the same validation order and derivation as AC-19, since it shares the same item request DTO.
+- **AC-21 (fix the existing `POST /bills` discount bug)**: today, `CreateBill` never validates `req.Discount < 0` and never sets `bills.total_item_discount` / `general_discount`, so any manual bill created with `discount > 0` already violates the database's `check_bills_discount_composition` constraint and fails with an unhandled `500`. `CreateBill` gains the same `req.Discount < 0` guard `UpdateDraftBill` already has, and both endpoints reject `line_total < 0` with `400 VALIDATION_FAILED` before it can produce a negative `final_price` and fail at the database layer instead.
+
+## Options considered
+
+### Option 1: Add `discount_amount` to the shared item request DTO, client round trips it
+
+Add the field to `CreateBillItemRequest` (already shared by `POST /bills` and `PUT /bills/{id}`). The client must resend each item's current `discount_amount` on every edit, the same way it already must resend `unit_price` and `line_total`, since the endpoint replaces the whole item list.
+
+**Pros**:
+- Matches the endpoint's existing "resend the full item" contract exactly, no new mental model for the client
+- One field, no new endpoint, no change to the delete and recreate mechanics that already work
+- Same DTO serves both create and edit, so behavior cannot drift between the two entry points
+
+**Cons**:
+- A client that forgets to resend `discount_amount` silently loses it, exactly today's failure mode, just now opt in instead of guaranteed. The mobile app must be updated before this is safe in practice.
+
+### Option 2: Redesign `PUT /bills/{id}` as a partial patch (only sent fields change, unlisted items are left alone)
+
+Stop deleting and recreating every item on every edit; instead, update only the items and fields present in the request.
+
+**Pros**:
+- Fixes the same class of data loss for every field, not just `discount_amount`; an edit to the merchant name would no longer require resending the entire item list
+
+**Cons**:
+- A materially larger change than the question asked: rewrites `UpdateDraftBill`'s core mechanics, its concurrency story (the delete and recreate under one `bills.version` check), and the API contract every existing client already relies on
+- Introduces new ambiguity (how does a client delete an item, versus not mentioning it?) that needs its own design pass
+
+### Option 3: Keep the current design, accept that manual edit converts item discounts to general
+
+**Pros**:
+- Zero backend change
+
+**Cons**:
+- Directly contradicts AC-17's stated goal the moment a user does the expected next step after OCR (reassigning items), which is not an edge case, it is the normal path
+
+## Decision
+
+**Chosen option**: Option 1: Add `discount_amount` to the shared item request DTO, client round trips it
+
+## Rationale
+
+Option 2 solves a real, broader problem (the endpoint's replace everything mechanics) but is a materially different, larger decision than what was asked, and this spec's job is the smallest change that closes the AC-17 gap, not a redesign of the edit endpoint's concurrency model. Option 3 was rejected because it leaves the feature broken for the workflow it was built for. Option 1 costs one field and matches a pattern (resend the full state) the client already implements correctly for every other item field; the cost of forgetting to resend it is real but is a mobile app implementation detail to get right when it adopts the field, not a backend design flaw, and does not need this endpoint's replace semantics to change.
+
+## Feature design
+
+**Data model sketch**: No new columns. `bill_items.discount_amount` and `bill_items.final_price` (from migration `000007_bill_item_discount_v1.sql`) already exist and already carry the `CHECK (final_price = line_total - discount_amount)` constraint that enforces this at the database layer.
+
+**API surface**:
+
+| Endpoint | Method | Key inputs | Key outputs | Auth | Key errors |
+|---|---|---|---|---|---|
+| /bills | POST | `items[].discount_amount` (int64, optional, default 0) | `bill.items[].discount_amount`, `.final_price`, `bill.total_item_discount`, `.general_discount` | bearer, Captain or group member | 400 VALIDATION_FAILED |
+| /bills/{id} | PUT | `items[].discount_amount` (int64, optional, default 0) | same as above | bearer, Captain or Creditor | 400 VALIDATION_FAILED, 409 VERSION_CONFLICT |
+
+**Value sourcing**:
+
+| Action | Value produced / displayed | Source |
+|---|---|---|
+| POST /bills, PUT /bills/{id} | `item.discount_amount` | request body `items[].discount_amount`, defaults to 0 when omitted |
+| POST /bills, PUT /bills/{id} | `item.line_total` (used to validate `discount_amount` and compute `final_price`) | the **derived** value: request `line_total` if nonzero, else `unit_price × quantity` (existing fallback), never the raw request field directly |
+| POST /bills, PUT /bills/{id} | `item.final_price` | derived, `item.line_total - item.discount_amount`, never accepted from the client |
+| POST /bills, PUT /bills/{id} | `bill.total_item_discount` | derived, `sum(item.discount_amount)` across the request's items |
+| POST /bills, PUT /bills/{id} | `bill.general_discount` | derived, `request.discount - total_item_discount` (existing `discount` field keeps its current meaning: the combined total, gross subtotal in, combined discount out, exactly today's contract) |
+
+**Contract carried over unchanged**: `bill.subtotal` in the request must be the **gross** sum of item `line_total`s (before any discount), and `bill.discount` must be the **combined** total (item plus general), exactly as today. This spec does not change or re-validate that contract at write time; a client that violates it still surfaces as `SUBTOTAL_MISMATCH` / `TOTAL_MISMATCH` at `/bills/{id}/review` via the existing `evaluateAllocation` reconciliation, unchanged.
+
+**Key invariants**:
+- `item.line_total >= 0` for every item, else `400 VALIDATION_FAILED` (new: today a negative `line_total` reaches the database and fails the `bill_items_check` / `check_bill_items_discount` constraints as an unhandled `500` instead of a clean `400`)
+- `0 <= item.discount_amount <= item.line_total` (the derived value above) for every item, else `400 VALIDATION_FAILED` naming the failing item's index
+- `item.final_price = item.line_total - item.discount_amount` always, computed server side, never accepted as client input
+- `bill.discount >= 0` for both endpoints (today only `UpdateDraftBill` checks this; `CreateBill` gains the same guard, see AC-21), and `bill.general_discount >= 0`, else `400 VALIDATION_FAILED`
+- `bill.discount = bill.total_item_discount + bill.general_discount`, matching the `check_bills_discount_composition` constraint already enforced at the database layer
+
+**Security model**: Unchanged. Same authorization as the rest of `PUT /bills/{id}` and `POST /bills` (Captain, or the Creditor for edit; any active group member for create): no new roles, no new ownership rule.
+
+**Critical test scenarios**:
+- Happy path: apply an OCR candidate carrying an item discount, then `PUT` the bill reassigning items to distinct members while resending the same `discount_amount`; `total_item_discount` and each item's `discount_amount`/`final_price` are unchanged after the edit, verifies **AC-19**.
+- Failure case: `PUT` an item with `discount_amount` greater than its **derived** `line_total` (send `line_total: 0, unit_price: 100000, quantity: "2"` with `discount_amount: 250000`, which must validate against the derived `200000`, not the literal `0`); the request is rejected with `400 VALIDATION_FAILED` and no partial write occurs, verifies **AC-19**.
+- Symmetry: `POST /bills` with one item carrying `discount_amount`; the created item's `final_price` and the bill's `total_item_discount` reflect it exactly as `PUT` would, verifies **AC-20**.
+- Regression: `POST /bills` with `discount: 20000` and no per item discount (today's bug); the bill is created successfully with `total_item_discount: 0`, `general_discount: 20000`, no database constraint error, verifies **AC-21**.
+
+## Build plan
+
+1. Add `DiscountAmount int64` to `CreateBillItemRequest` in `internal/modules/bill/usecase/service.go` (shared by both endpoints), satisfies **AC-19**, **AC-20**.
+2. Add the missing `req.Discount < 0` guard to `CreateBill` (parity with `UpdateDraftBill`) and an `item.LineTotal >= 0` guard to both endpoints' item loops, both `400 VALIDATION_FAILED`, satisfies **AC-21**.
+3. In both endpoints' item construction loop, after `lineTotal` is derived (the existing `unit_price × quantity` fallback), validate `0 <= discount_amount <= lineTotal` (naming the failing item's index in the error), then compute `final_price = lineTotal - discount_amount` and accumulate `total_item_discount`, satisfies **AC-19**, **AC-20**.
+4. After the item loop, derive `general_discount = discount - total_item_discount`, reject with `400 VALIDATION_FAILED` if negative, and set `domain.Bill.TotalItemDiscount` / `.GeneralDiscount` from it, replacing the current `GeneralDiscount = req.Discount` fallback in both usecase paths, satisfies **AC-19**, **AC-20**, **AC-21**.
+5. Update `docs/openapi.yaml` for both endpoints' request schemas, satisfies **AC-19**, **AC-20**.
+6. Add the four critical test scenarios above as usecase tests (mirroring the existing `TestUpdateDraftBill_*` / `TestCreateBill_*` table in `internal/modules/bill/usecase/service_test.go`), satisfies **AC-19**, **AC-20**, **AC-21**.
+
+No migration: both database columns already exist from `000007_bill_item_discount_v1.sql`; this is an additive, backward compatible JSON field (omitted means 0, identical to today's behavior).
+
+## Consequences
+
+**Positive**:
+- Item level promotions survive the normal OCR reassignment workflow instead of only surviving until the first manual touch
+- `POST` and `PUT` stay behaviorally identical for discount handling, since they share one DTO and one validation path
+- Fixes a live bug: `POST /bills` with `discount > 0` currently fails with an unhandled `500` (AC-21)
+
+**Negative / tradeoffs**:
+- The mobile app (`PaySplit-FE`) must start sending `discount_amount` on every item edit once it wants to preserve discounts; until it does, the observed behavior is unchanged from today (discount silently becomes general on edit), it is opt in, not automatically fixed by this backend change alone
+- One more field for every future client of these two endpoints to get right on every write
+- Rollout ordering risk: a client that starts sending per item `discount_amount` but stops keeping `discount` as the correct combined (item plus general) total will get a new `400 VALIDATION_FAILED` (`general_discount < 0`) on a request that used to succeed. The client contract for `discount` does not change, only becomes enforced; call this out to the mobile team before rollout, not as a breaking API change but as a now visible violation of a rule that already existed
+
+**Neutral**:
+- Does not touch the "replace all items on every edit" mechanics; a client that only ever means to change one field must still resend the full item list, unchanged from today
+
+## Follow-up
+
+- [ ] Update `PaySplit-FE`'s bill edit screen and its request models to send `discount_amount` when reassigning OCR extracted items, otherwise this fix has no user facing effect
+- [ ] Spec 0004's build plan step 6 (candidate review UI showing original price, discount badge, final price) should also cover the edit screen sending this field back, not only displaying it
+- [ ] Confirm with the mobile team that `PaySplit-FE` already sends `discount` as the gross combined total (not just the general portion) before this ships, per the rollout ordering risk above

--- a/docs/specs/0003-bill-ocr-v1/index.md
+++ b/docs/specs/0003-bill-ocr-v1/index.md
@@ -1,7 +1,7 @@
 # 0003. Bill and OCR v1
 
 **Date**: 2026-08-17
-**Status**: In Progress
+**Status**: Accepted
 
 ## Summary
 
@@ -13,6 +13,7 @@ Bill and OCR v1 lets a group member create a manual bill or upload up to five re
 2. [Allocation and review](0002-allocation-review.md) defines draft editing, item ratios, preview calculation, reconciliation, optimistic locking, and explicit review.
 3. [Finalize and void](0003-finalize-void.md) defines floor allocation with Creditor remainder absorption, immutable share snapshots, debt creation, notification jobs, and safe void with replacement history.
 4. [Item discount OCR parsing](0004-item-discount-ocr-parsing.md) defines sequential folding of item promotions, net item pricing, and separation of item versus general discounts.
+5. [Manual edit preserves item level discount](0005-manual-edit-item-discount.md) defines how `POST /bills` and `PUT /bills/{id}` accept and validate `discount_amount` per item so a manual edit does not erase what OCR extracted.
 
 The cross child contract is that every bill scoped row carries `group_id`, every money value is `bigint` VND, every mutable draft operation checks and increments `bills.version`, and every mutation that changes bill meaning clears `reviewed_at` and `reviewed_by_member_id`.
 

--- a/docs/specs/0003-bill-ocr-v1/verify.md
+++ b/docs/specs/0003-bill-ocr-v1/verify.md
@@ -38,6 +38,14 @@ Fixture: `testdata/bills/image.png`, a 425 by 470 PNG of a restaurant receipt.
 - [x] The 30 day raw OCR purge really deletes. Both job rows were aged 40 days past `completed_at`, the server restarted so the periodic job fired, and afterwards `raw_response` is NULL on both rows while `candidate` is untouched. Five expired idempotency keys were deleted in the same pass. This is the worker that was never wired up before. (satisfies AC-11, AC-13)
 - [x] Void keeps history. `POST /api/v1/bills/{id}/void` with the current version returns 200. The bill and its debt both move to `voided`, and the two `bill_shares` rows survive with their sum still exactly 100001. A void without the version returns `409 VERSION_CONFLICT`. (satisfies AC-11)
 
+### Item discount OCR parsing (spec 0004), live provider run 2026 08 21
+
+Fixture: `testdata/bills/anh2.png`, a real VinCommerce (VM Royal City) supermarket receipt with three interleaved `KM` promotion lines, the exact real world pattern spec 0004 was designed against.
+
+- [x] `go test -run TestIntegration_LlamaExtract ./internal/platform/ocr/llamaextract/` passes in 22.7 seconds against the live LlamaExtract provider (not a synthetic fixture). Raw JSON returned three separate `{"name":"KM","line_total":-64125}`-style lines interleaved with five real items and `"subtotal":null`. (satisfies AC-3)
+- [x] The normalizer folds all three real `KM` lines into their preceding item correctly: 5 clean items in the candidate, zero orphan lines, each with `discount_amount`/`final_price` matching `line_total` minus its immediately following `KM` line (e.g. `149625 - 64125 = 85500`). (satisfies AC-15)
+- [x] Aggregate reconciliation on real provider output, not synthetic numbers: `subtotal` (derived from item sum, since the provider returned `subtotal: null`) `545500`, `total_item_discount` `192200`, `general_discount` `0`, `discount` `192200`, `total` `353300`, exactly matching the raw provider's own `total: 353300` with no `mismatch_warning`. (satisfies AC-17, AC-18)
+
 ## Not exercised in this run
 - Multi image drafts of two to five files. Only a single image draft was run.
 - Concurrent finalize and concurrent edit races. Covered by the integration tests, not by a live run.
@@ -58,3 +66,16 @@ Fixture: `testdata/bills/image.png`, a 425 by 470 PNG of a restaurant receipt.
 - [x] AC-12: List and detail reads expose bill state, breakdown, and signed image URLs.
 - [x] AC-13: Draft deletion removes bill records and enqueues Cloudinary media cleanup jobs.
 - [x] AC-14: In memory calculation and short database transactions protect performance and safety.
+- [x] AC-19: `PUT /bills/{id}` accepts `discount_amount` per item, validates it against the derived `line_total`, and item level discounts survive a manual edit.
+- [x] AC-20: `POST /bills` accepts the same `discount_amount` field with the same validation and derivation as `PUT`.
+- [x] AC-21: `CreateBill` rejects a negative `discount` and no longer violates `check_bills_discount_composition` when `discount > 0` with no item level discount.
+
+## Manual edit item discount (spec 0005), runtime evidence 2026 08 21
+
+Server started with `go run ./cmd/api`, bound to `localhost:8080`, against the PostgreSQL 18 container on port 5433.
+
+- [x] `POST /bills` with `discount: 20000` and no item level discount returns `201` (previously `500`, `check_bills_discount_composition` violation): response carries `total_item_discount: 0`, `general_discount: 20000`, `discount: 20000`. (satisfies AC-21)
+- [x] `PUT /bills/{id}` with one item carrying `discount_amount: 15000` on a `line_total: 50000` item returns `200`: response carries `item.discount_amount: 15000`, `item.final_price: 35000`, `bill.total_item_discount: 15000`. (satisfies AC-19)
+- [x] `PUT /bills/{id}` with `discount_amount: 999999` on a `line_total: 50000` item returns `400 VALIDATION_FAILED`, `"item 0: discount_amount must be between 0 and line_total"`, and does not write anything (bill version unchanged). (satisfies AC-19)
+- [x] `go test ./internal/modules/bill/usecase/...` covers `discount_amount` exceeding the **derived** `line_total` (`unit_price × quantity` fallback, not the raw request value), the item discount round trip through `UpdateDraftBill` reassignment, and the `CreateBill` discount composition regression. (satisfies AC-19, AC-20, AC-21)
+- [x] `go test ./internal/modules/bill/repository/postgres/...` against the live database, migrations 1 through 7 applied, all pass. (satisfies AC-19, AC-20, AC-21)

--- a/internal/modules/admin/repository/postgres/sqlc/models.go
+++ b/internal/modules/admin/repository/postgres/sqlc/models.go
@@ -49,6 +49,8 @@ type Bill struct {
 	MismatchCodes      []string           `json:"mismatch_codes"`
 	ReviewedAt         pgtype.Timestamptz `json:"reviewed_at"`
 	ReviewedByMemberID pgtype.UUID        `json:"reviewed_by_member_id"`
+	TotalItemDiscount  int64              `json:"total_item_discount"`
+	GeneralDiscount    int64              `json:"general_discount"`
 }
 
 type BillIdempotencyKey struct {
@@ -77,16 +79,18 @@ type BillImage struct {
 }
 
 type BillItem struct {
-	ID        pgtype.UUID        `json:"id"`
-	BillID    pgtype.UUID        `json:"bill_id"`
-	GroupID   pgtype.UUID        `json:"group_id"`
-	Name      string             `json:"name"`
-	Quantity  pgtype.Numeric     `json:"quantity"`
-	UnitPrice int64              `json:"unit_price"`
-	LineTotal int64              `json:"line_total"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
-	Position  int16              `json:"position"`
+	ID             pgtype.UUID        `json:"id"`
+	BillID         pgtype.UUID        `json:"bill_id"`
+	GroupID        pgtype.UUID        `json:"group_id"`
+	Name           string             `json:"name"`
+	Quantity       pgtype.Numeric     `json:"quantity"`
+	UnitPrice      int64              `json:"unit_price"`
+	LineTotal      int64              `json:"line_total"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+	Position       int16              `json:"position"`
+	DiscountAmount int64              `json:"discount_amount"`
+	FinalPrice     int64              `json:"final_price"`
 }
 
 type BillItemAssignment struct {
@@ -125,6 +129,7 @@ type Debt struct {
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	SettledAt        pgtype.Timestamptz `json:"settled_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	VoidedAt         pgtype.Timestamptz `json:"voided_at"`
 }
 
 type Group struct {

--- a/internal/modules/auth/repository/postgres/sqlc/models.go
+++ b/internal/modules/auth/repository/postgres/sqlc/models.go
@@ -49,6 +49,8 @@ type Bill struct {
 	MismatchCodes      []string           `json:"mismatch_codes"`
 	ReviewedAt         pgtype.Timestamptz `json:"reviewed_at"`
 	ReviewedByMemberID pgtype.UUID        `json:"reviewed_by_member_id"`
+	TotalItemDiscount  int64              `json:"total_item_discount"`
+	GeneralDiscount    int64              `json:"general_discount"`
 }
 
 type BillIdempotencyKey struct {
@@ -77,16 +79,18 @@ type BillImage struct {
 }
 
 type BillItem struct {
-	ID        pgtype.UUID        `json:"id"`
-	BillID    pgtype.UUID        `json:"bill_id"`
-	GroupID   pgtype.UUID        `json:"group_id"`
-	Name      string             `json:"name"`
-	Quantity  pgtype.Numeric     `json:"quantity"`
-	UnitPrice int64              `json:"unit_price"`
-	LineTotal int64              `json:"line_total"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
-	Position  int16              `json:"position"`
+	ID             pgtype.UUID        `json:"id"`
+	BillID         pgtype.UUID        `json:"bill_id"`
+	GroupID        pgtype.UUID        `json:"group_id"`
+	Name           string             `json:"name"`
+	Quantity       pgtype.Numeric     `json:"quantity"`
+	UnitPrice      int64              `json:"unit_price"`
+	LineTotal      int64              `json:"line_total"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+	Position       int16              `json:"position"`
+	DiscountAmount int64              `json:"discount_amount"`
+	FinalPrice     int64              `json:"final_price"`
 }
 
 type BillItemAssignment struct {
@@ -125,6 +129,7 @@ type Debt struct {
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	SettledAt        pgtype.Timestamptz `json:"settled_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	VoidedAt         pgtype.Timestamptz `json:"voided_at"`
 }
 
 type Group struct {

--- a/internal/modules/bill/domain/bill.go
+++ b/internal/modules/bill/domain/bill.go
@@ -48,7 +48,9 @@ type Bill struct {
 	Subtotal           int64       `json:"subtotal"`
 	ServiceCharge      int64       `json:"service_charge"`
 	VAT                int64       `json:"vat"`
-	Discount           int64       `json:"discount"`
+	Discount           int64       `json:"discount"` // Tổng giảm giá = TotalItemDiscount + GeneralDiscount
+	TotalItemDiscount  int64       `json:"total_item_discount"` // Giảm giá gắn theo từng món (Spec 3 AC-17)
+	GeneralDiscount    int64       `json:"general_discount"`   // Giảm giá chung/voucher của cả hóa đơn (Spec 3 AC-17)
 	Total              int64       `json:"total"`
 	SplitMethod        SplitMethod `json:"split_method"`
 	MismatchCodes      []string    `json:"mismatch_codes"`
@@ -79,17 +81,19 @@ type BillImage struct {
 
 // BillItem đại diện cho một món hoặc dịch vụ trong hóa đơn.
 type BillItem struct {
-	ID          uuid.UUID             `json:"id"`
-	BillID      uuid.UUID             `json:"bill_id"`
-	GroupID     uuid.UUID             `json:"group_id"`
-	Name        string                `json:"name"`
-	Quantity    string                `json:"quantity"` // Chuỗi số thập phân, ví dụ "1", "2.5"
-	UnitPrice   int64                 `json:"unit_price"`
-	LineTotal   int64                 `json:"line_total"`
-	Position    int16                 `json:"position"`
-	CreatedAt   time.Time             `json:"created_at"`
-	UpdatedAt   time.Time             `json:"updated_at"`
-	Assignments []*BillItemAssignment `json:"assignments,omitempty"`
+	ID             uuid.UUID             `json:"id"`
+	BillID         uuid.UUID             `json:"bill_id"`
+	GroupID        uuid.UUID             `json:"group_id"`
+	Name           string                `json:"name"`
+	Quantity       string                `json:"quantity"` // Chuỗi số thập phân, ví dụ "1", "2.5"
+	UnitPrice      int64                 `json:"unit_price"`
+	LineTotal      int64                 `json:"line_total"`      // Tổng tiền gốc trước khuyến mãi
+	DiscountAmount int64                 `json:"discount_amount"` // Khuyến mãi gắn riêng cho món này (Spec 3 AC-15)
+	FinalPrice     int64                 `json:"final_price"`     // Giá còn lại = LineTotal - DiscountAmount, dùng để chia cho thành viên (Spec 3 AC-17)
+	Position       int16                 `json:"position"`
+	CreatedAt      time.Time             `json:"created_at"`
+	UpdatedAt      time.Time             `json:"updated_at"`
+	Assignments    []*BillItemAssignment `json:"assignments,omitempty"`
 }
 
 // BillItemAssignment ghi nhận thành viên gánh món nào và tỷ trọng/portions (Spec 3 AC-5).

--- a/internal/modules/bill/domain/ocr.go
+++ b/internal/modules/bill/domain/ocr.go
@@ -13,28 +13,40 @@ const (
 
 	// WarningLowConfidence cảnh báo độ tin cậy của OCR dưới ngưỡng tiêu chuẩn.
 	WarningLowConfidence = "LOW_CONFIDENCE"
+
+	// WarningOCROrphanItemDiscount cảnh báo dòng khuyến mãi xuất hiện trước bất kỳ món hợp lệ nào
+	// hoặc không có món liền trước, nên được gộp vào giảm giá chung của hóa đơn (Spec 3 AC-16).
+	WarningOCROrphanItemDiscount = "OCR_ORPHAN_ITEM_DISCOUNT"
+
+	// WarningOCRItemDiscountExceeded cảnh báo giảm giá của một món vượt quá giá gốc của chính món
+	// đó, phần vượt được chuyển sang giảm giá chung (Spec 3 AC-16).
+	WarningOCRItemDiscountExceeded = "OCR_ITEM_DISCOUNT_EXCEEDED"
 )
 
 // OCRCandidate đại diện cho bản ghi trích xuất hóa đơn chuẩn hóa từ AI / Vision LLM.
 // Dữ liệu này được lưu trữ dạng JSONB trong cột ocr_jobs.candidate và chỉ được áp dụng
 // vào hóa đơn khi người dùng thực hiện apply một cách tường minh (Spec 3 AC-3, AC-4).
 type OCRCandidate struct {
-	MerchantName  *string            `json:"merchant_name,omitempty"`
-	BillDate      *string            `json:"bill_date,omitempty"` // Định dạng ISO YYYY-MM-DD
-	Items         []OCRCandidateItem `json:"items"`
-	Subtotal      int64              `json:"subtotal"`
-	ServiceCharge int64              `json:"service_charge"`
-	VAT           int64              `json:"vat"`
-	Discount      int64              `json:"discount"`
-	Total         int64              `json:"total"`
-	Confidence    *float64           `json:"confidence,omitempty"`
-	Warnings      []string           `json:"warnings"`
+	MerchantName      *string            `json:"merchant_name,omitempty"`
+	BillDate          *string            `json:"bill_date,omitempty"` // Định dạng ISO YYYY-MM-DD
+	Items             []OCRCandidateItem `json:"items"`
+	Subtotal          int64              `json:"subtotal"`
+	TotalItemDiscount int64              `json:"total_item_discount"` // Tổng giảm giá gắn theo từng món (Spec 3 AC-17)
+	GeneralDiscount   int64              `json:"general_discount"`   // Giảm giá chung của cả hóa đơn (voucher, Spec 3 AC-17)
+	ServiceCharge     int64              `json:"service_charge"`
+	VAT               int64              `json:"vat"`
+	Discount          int64              `json:"discount"` // Tổng giảm giá = TotalItemDiscount + GeneralDiscount
+	Total             int64              `json:"total"`
+	Confidence        *float64           `json:"confidence,omitempty"`
+	Warnings          []string           `json:"warnings"`
 }
 
 // OCRCandidateItem đại diện cho một món hoặc dịch vụ được bóc tách từ hóa đơn.
 type OCRCandidateItem struct {
-	Name      string `json:"name"`
-	Quantity  string `json:"quantity"` // Chuỗi thập phân, ví dụ: "1", "2.5"
-	UnitPrice int64  `json:"unit_price"`
-	LineTotal int64  `json:"line_total"`
+	Name           string `json:"name"`
+	Quantity       string `json:"quantity"` // Chuỗi thập phân, ví dụ: "1", "2.5"
+	UnitPrice      int64  `json:"unit_price"`
+	LineTotal      int64  `json:"line_total"`      // Tổng tiền gốc trước khuyến mãi
+	DiscountAmount int64  `json:"discount_amount"` // Khuyến mãi gắn riêng cho món này (Spec 3 AC-15)
+	FinalPrice     int64  `json:"final_price"`     // Giá còn lại = LineTotal - DiscountAmount
 }

--- a/internal/modules/bill/repository/postgres/queries/bill.sql
+++ b/internal/modules/bill/repository/postgres/queries/bill.sql
@@ -10,6 +10,8 @@ INSERT INTO bills (
     service_charge,
     vat,
     discount,
+    total_item_discount,
+    general_discount,
     total,
     split_method,
     mismatch_codes,
@@ -18,7 +20,7 @@ INSERT INTO bills (
     created_at,
     updated_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 1, now(), now()
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, 1, now(), now()
 ) RETURNING *;
 
 -- name: GetBillByID :one
@@ -59,15 +61,17 @@ SET merchant_name = $3,
     service_charge = $6,
     vat = $7,
     discount = $8,
-    total = $9,
-    split_method = $10,
-    mismatch_codes = $11,
+    total_item_discount = $9,
+    general_discount = $10,
+    total = $11,
+    split_method = $12,
+    mismatch_codes = $13,
     status = 'draft',
     reviewed_at = NULL,
     reviewed_by_member_id = NULL,
     version = version + 1,
     updated_at = now()
-WHERE id = $1 AND group_id = $2 AND status IN ('draft', 'reviewed') AND version = $12
+WHERE id = $1 AND group_id = $2 AND status IN ('draft', 'reviewed') AND version = $14
 RETURNING *;
 
 -- name: ReviewBill :one
@@ -140,11 +144,13 @@ INSERT INTO bill_items (
     quantity,
     unit_price,
     line_total,
+    discount_amount,
+    final_price,
     position,
     created_at,
     updated_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, now(), now()
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, now(), now()
 ) RETURNING *;
 
 -- name: ListBillItems :many

--- a/internal/modules/bill/repository/postgres/repository.go
+++ b/internal/modules/bill/repository/postgres/repository.go
@@ -77,20 +77,22 @@ func (r *postgresRepository) CreateBill(ctx context.Context, p repository.Create
 	}
 
 	dbBill, err := q.CreateBill(ctx, sqlc.CreateBillParams{
-		ID:               pgtype.UUID{Bytes: p.Bill.ID, Valid: true},
-		GroupID:          pgtype.UUID{Bytes: p.Bill.GroupID, Valid: true},
-		CreditorMemberID: pgtype.UUID{Bytes: p.Bill.CreditorMemberID, Valid: true},
-		Status:           statusStr,
-		MerchantName:     merchantName,
-		BillDate:         billDate,
-		Subtotal:         p.Bill.Subtotal,
-		ServiceCharge:    p.Bill.ServiceCharge,
-		Vat:              p.Bill.VAT,
-		Discount:         p.Bill.Discount,
-		Total:            p.Bill.Total,
-		SplitMethod:      splitMethod,
-		MismatchCodes:    mismatchCodes,
-		ReplacesBillID:   replacesID,
+		ID:                pgtype.UUID{Bytes: p.Bill.ID, Valid: true},
+		GroupID:           pgtype.UUID{Bytes: p.Bill.GroupID, Valid: true},
+		CreditorMemberID:  pgtype.UUID{Bytes: p.Bill.CreditorMemberID, Valid: true},
+		Status:            statusStr,
+		MerchantName:      merchantName,
+		BillDate:          billDate,
+		Subtotal:          p.Bill.Subtotal,
+		ServiceCharge:     p.Bill.ServiceCharge,
+		Vat:               p.Bill.VAT,
+		Discount:          p.Bill.Discount,
+		TotalItemDiscount: p.Bill.TotalItemDiscount,
+		GeneralDiscount:   p.Bill.GeneralDiscount,
+		Total:             p.Bill.Total,
+		SplitMethod:       splitMethod,
+		MismatchCodes:     mismatchCodes,
+		ReplacesBillID:    replacesID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create bill row: %w", err)
@@ -121,14 +123,16 @@ func (r *postgresRepository) CreateBill(ctx context.Context, p repository.Create
 		}
 
 		dbItem, err := q.CreateBillItem(ctx, sqlc.CreateBillItemParams{
-			ID:        pgtype.UUID{Bytes: item.ID, Valid: true},
-			BillID:    pgtype.UUID{Bytes: p.Bill.ID, Valid: true},
-			GroupID:   pgtype.UUID{Bytes: p.Bill.GroupID, Valid: true},
-			Name:      item.Name,
-			Quantity:  qtyNum,
-			UnitPrice: item.UnitPrice,
-			LineTotal: item.LineTotal,
-			Position:  item.Position,
+			ID:             pgtype.UUID{Bytes: item.ID, Valid: true},
+			BillID:         pgtype.UUID{Bytes: p.Bill.ID, Valid: true},
+			GroupID:        pgtype.UUID{Bytes: p.Bill.GroupID, Valid: true},
+			Name:           item.Name,
+			Quantity:       qtyNum,
+			UnitPrice:      item.UnitPrice,
+			LineTotal:      item.LineTotal,
+			DiscountAmount: item.DiscountAmount,
+			FinalPrice:     item.FinalPrice,
+			Position:       item.Position,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("create bill item %s: %w", item.Name, err)
@@ -443,18 +447,20 @@ func (r *postgresRepository) UpdateDraftBill(ctx context.Context, p repository.U
 	}
 
 	dbBill, err := q.UpdateDraftBill(ctx, sqlc.UpdateDraftBillParams{
-		ID:            pgtype.UUID{Bytes: p.Bill.ID, Valid: true},
-		GroupID:       pgtype.UUID{Bytes: p.Bill.GroupID, Valid: true},
-		MerchantName:  merchantName,
-		BillDate:      billDate,
-		Subtotal:      p.Bill.Subtotal,
-		ServiceCharge: p.Bill.ServiceCharge,
-		Vat:           p.Bill.VAT,
-		Discount:      p.Bill.Discount,
-		Total:         p.Bill.Total,
-		SplitMethod:   splitMethod,
-		MismatchCodes: mismatchCodes,
-		Version:       p.ExpectedVersion,
+		ID:                pgtype.UUID{Bytes: p.Bill.ID, Valid: true},
+		GroupID:           pgtype.UUID{Bytes: p.Bill.GroupID, Valid: true},
+		MerchantName:      merchantName,
+		BillDate:          billDate,
+		Subtotal:          p.Bill.Subtotal,
+		ServiceCharge:     p.Bill.ServiceCharge,
+		Vat:               p.Bill.VAT,
+		Discount:          p.Bill.Discount,
+		TotalItemDiscount: p.Bill.TotalItemDiscount,
+		GeneralDiscount:   p.Bill.GeneralDiscount,
+		Total:             p.Bill.Total,
+		SplitMethod:       splitMethod,
+		MismatchCodes:     mismatchCodes,
+		Version:           p.ExpectedVersion,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -476,14 +482,16 @@ func (r *postgresRepository) UpdateDraftBill(ctx context.Context, p repository.U
 		}
 
 		dbItem, err := q.CreateBillItem(ctx, sqlc.CreateBillItemParams{
-			ID:        pgtype.UUID{Bytes: item.ID, Valid: true},
-			BillID:    pgtype.UUID{Bytes: p.Bill.ID, Valid: true},
-			GroupID:   pgtype.UUID{Bytes: p.Bill.GroupID, Valid: true},
-			Name:      item.Name,
-			Quantity:  qtyNum,
-			UnitPrice: item.UnitPrice,
-			LineTotal: item.LineTotal,
-			Position:  item.Position,
+			ID:             pgtype.UUID{Bytes: item.ID, Valid: true},
+			BillID:         pgtype.UUID{Bytes: p.Bill.ID, Valid: true},
+			GroupID:        pgtype.UUID{Bytes: p.Bill.GroupID, Valid: true},
+			Name:           item.Name,
+			Quantity:       qtyNum,
+			UnitPrice:      item.UnitPrice,
+			LineTotal:      item.LineTotal,
+			DiscountAmount: item.DiscountAmount,
+			FinalPrice:     item.FinalPrice,
+			Position:       item.Position,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("create replacement bill item %s: %w", item.Name, err)
@@ -1186,6 +1194,8 @@ func toDomainBill(b *sqlc.Bill) *domain.Bill {
 		ServiceCharge:      b.ServiceCharge,
 		VAT:                b.Vat,
 		Discount:           b.Discount,
+		TotalItemDiscount:  b.TotalItemDiscount,
+		GeneralDiscount:    b.GeneralDiscount,
 		Total:              b.Total,
 		SplitMethod:        domain.SplitMethod(b.SplitMethod),
 		MismatchCodes:      b.MismatchCodes,
@@ -1226,16 +1236,18 @@ func toDomainBillItem(it *sqlc.BillItem) *domain.BillItem {
 	}
 
 	return &domain.BillItem{
-		ID:        uuid.UUID(it.ID.Bytes),
-		BillID:    uuid.UUID(it.BillID.Bytes),
-		GroupID:   uuid.UUID(it.GroupID.Bytes),
-		Name:      it.Name,
-		Quantity:  qtyStr,
-		UnitPrice: it.UnitPrice,
-		LineTotal: it.LineTotal,
-		Position:  it.Position,
-		CreatedAt: it.CreatedAt.Time,
-		UpdatedAt: it.UpdatedAt.Time,
+		ID:             uuid.UUID(it.ID.Bytes),
+		BillID:         uuid.UUID(it.BillID.Bytes),
+		GroupID:        uuid.UUID(it.GroupID.Bytes),
+		Name:           it.Name,
+		Quantity:       qtyStr,
+		UnitPrice:      it.UnitPrice,
+		LineTotal:      it.LineTotal,
+		DiscountAmount: it.DiscountAmount,
+		FinalPrice:     it.FinalPrice,
+		Position:       it.Position,
+		CreatedAt:      it.CreatedAt.Time,
+		UpdatedAt:      it.UpdatedAt.Time,
 	}
 }
 

--- a/internal/modules/bill/repository/postgres/repository_integration_test.go
+++ b/internal/modules/bill/repository/postgres/repository_integration_test.go
@@ -140,14 +140,15 @@ func TestIntegration_CreateAndGetBill(t *testing.T) {
 	itemID := uuid.New()
 	items := []*domain.BillItem{
 		{
-			ID:        itemID,
-			BillID:    billID,
-			GroupID:   groupID,
-			Name:      "Phở Đặc Biệt",
-			Quantity:  "1",
-			UnitPrice: 100000,
-			LineTotal: 100000,
-			Position:  0,
+			ID:         itemID,
+			BillID:     billID,
+			GroupID:    groupID,
+			Name:       "Phở Đặc Biệt",
+			Quantity:   "1",
+			UnitPrice:  100000,
+			LineTotal:  100000,
+			FinalPrice: 100000,
+			Position:   0,
 			Assignments: []*domain.BillItemAssignment{
 				{
 					ID:         uuid.New(),
@@ -433,5 +434,76 @@ func TestIntegration_PurgeExpiredIdempotencyKeys(t *testing.T) {
 	}
 	if remaining != 0 {
 		t.Errorf("mong đợi bản ghi hết hạn bị xóa, còn lại %d", remaining)
+	}
+}
+
+// TestIntegration_CreateBill_ItemDiscountRoundTrips khớp Spec 3 AC-15, AC-17: discount_amount,
+// final_price theo món và total_item_discount, general_discount ở cấp bill phải ghi và đọc lại
+// đúng qua tầng repository thật, không chỉ đúng ở tầng usecase (satisfies AC-19, AC-20, AC-21 build
+// plan bước 3: chứng minh check_bills_discount_composition và check_bill_items_discount không bị
+// vi phạm khi discount_amount > 0).
+func TestIntegration_CreateBill_ItemDiscountRoundTrips(t *testing.T) {
+	pool := testPool(t)
+	repo := postgres.New(pool)
+	groupID, creditorID, _ := setupTestGroupAndMembers(t, pool)
+
+	billID := uuid.New()
+	itemID := uuid.New()
+	ctx := context.Background()
+
+	createdBill, err := repo.CreateBill(ctx, repository.CreateBillParams{
+		Bill: &domain.Bill{
+			ID:                billID,
+			GroupID:           groupID,
+			CreditorMemberID:  creditorID,
+			Status:            domain.BillStatusDraft,
+			Subtotal:          250000,
+			Discount:          80000,
+			TotalItemDiscount: 50000,
+			GeneralDiscount:   30000,
+			Total:             170000,
+			SplitMethod:       domain.SplitMethodEven,
+		},
+		Items: []*domain.BillItem{
+			{
+				ID:             itemID,
+				BillID:         billID,
+				GroupID:        groupID,
+				Name:           "Bò bít tết",
+				Quantity:       "1",
+				UnitPrice:      250000,
+				LineTotal:      250000,
+				DiscountAmount: 50000,
+				FinalPrice:     200000,
+				Position:       0,
+				Assignments: []*domain.BillItemAssignment{
+					{ID: uuid.New(), BillItemID: itemID, GroupID: groupID, MemberID: creditorID, Weight: "1.0000"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBill() error = %v", err)
+	}
+	if createdBill.TotalItemDiscount != 50000 || createdBill.GeneralDiscount != 30000 {
+		t.Errorf("expected total_item_discount 50000 and general_discount 30000 on create, got %d/%d",
+			createdBill.TotalItemDiscount, createdBill.GeneralDiscount)
+	}
+	if len(createdBill.Items) != 1 || createdBill.Items[0].DiscountAmount != 50000 || createdBill.Items[0].FinalPrice != 200000 {
+		t.Fatalf("expected item discount_amount 50000 and final_price 200000 on create, got %+v", createdBill.Items)
+	}
+
+	// Đọc lại từ database (không phải giá trị vừa truyền vào) để chứng minh cột thật sự lưu đúng,
+	// không chỉ đúng trên object trong bộ nhớ.
+	fetched, err := repo.GetBillByID(ctx, billID, groupID)
+	if err != nil {
+		t.Fatalf("GetBillByID() error = %v", err)
+	}
+	if fetched.TotalItemDiscount != 50000 || fetched.GeneralDiscount != 30000 || fetched.Discount != 80000 {
+		t.Errorf("expected persisted total_item_discount 50000, general_discount 30000, discount 80000, got %d/%d/%d",
+			fetched.TotalItemDiscount, fetched.GeneralDiscount, fetched.Discount)
+	}
+	if len(fetched.Items) != 1 || fetched.Items[0].DiscountAmount != 50000 || fetched.Items[0].FinalPrice != 200000 {
+		t.Fatalf("expected persisted item discount_amount 50000 and final_price 200000, got %+v", fetched.Items)
 	}
 }

--- a/internal/modules/bill/repository/postgres/sqlc/bill.sql.go
+++ b/internal/modules/bill/repository/postgres/sqlc/bill.sql.go
@@ -66,6 +66,8 @@ INSERT INTO bills (
     service_charge,
     vat,
     discount,
+    total_item_discount,
+    general_discount,
     total,
     split_method,
     mismatch_codes,
@@ -74,25 +76,27 @@ INSERT INTO bills (
     created_at,
     updated_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 1, now(), now()
-) RETURNING id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, 1, now(), now()
+) RETURNING id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id, total_item_discount, general_discount
 `
 
 type CreateBillParams struct {
-	ID               pgtype.UUID `json:"id"`
-	GroupID          pgtype.UUID `json:"group_id"`
-	CreditorMemberID pgtype.UUID `json:"creditor_member_id"`
-	Status           interface{} `json:"status"`
-	MerchantName     pgtype.Text `json:"merchant_name"`
-	BillDate         pgtype.Date `json:"bill_date"`
-	Subtotal         int64       `json:"subtotal"`
-	ServiceCharge    int64       `json:"service_charge"`
-	Vat              int64       `json:"vat"`
-	Discount         int64       `json:"discount"`
-	Total            int64       `json:"total"`
-	SplitMethod      string      `json:"split_method"`
-	MismatchCodes    []string    `json:"mismatch_codes"`
-	ReplacesBillID   pgtype.UUID `json:"replaces_bill_id"`
+	ID                pgtype.UUID `json:"id"`
+	GroupID           pgtype.UUID `json:"group_id"`
+	CreditorMemberID  pgtype.UUID `json:"creditor_member_id"`
+	Status            interface{} `json:"status"`
+	MerchantName      pgtype.Text `json:"merchant_name"`
+	BillDate          pgtype.Date `json:"bill_date"`
+	Subtotal          int64       `json:"subtotal"`
+	ServiceCharge     int64       `json:"service_charge"`
+	Vat               int64       `json:"vat"`
+	Discount          int64       `json:"discount"`
+	TotalItemDiscount int64       `json:"total_item_discount"`
+	GeneralDiscount   int64       `json:"general_discount"`
+	Total             int64       `json:"total"`
+	SplitMethod       string      `json:"split_method"`
+	MismatchCodes     []string    `json:"mismatch_codes"`
+	ReplacesBillID    pgtype.UUID `json:"replaces_bill_id"`
 }
 
 func (q *Queries) CreateBill(ctx context.Context, arg CreateBillParams) (Bill, error) {
@@ -107,6 +111,8 @@ func (q *Queries) CreateBill(ctx context.Context, arg CreateBillParams) (Bill, e
 		arg.ServiceCharge,
 		arg.Vat,
 		arg.Discount,
+		arg.TotalItemDiscount,
+		arg.GeneralDiscount,
 		arg.Total,
 		arg.SplitMethod,
 		arg.MismatchCodes,
@@ -137,6 +143,8 @@ func (q *Queries) CreateBill(ctx context.Context, arg CreateBillParams) (Bill, e
 		&i.MismatchCodes,
 		&i.ReviewedAt,
 		&i.ReviewedByMemberID,
+		&i.TotalItemDiscount,
+		&i.GeneralDiscount,
 	)
 	return i, err
 }
@@ -196,23 +204,27 @@ INSERT INTO bill_items (
     quantity,
     unit_price,
     line_total,
+    discount_amount,
+    final_price,
     position,
     created_at,
     updated_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, now(), now()
-) RETURNING id, bill_id, group_id, name, quantity, unit_price, line_total, created_at, updated_at, position
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, now(), now()
+) RETURNING id, bill_id, group_id, name, quantity, unit_price, line_total, created_at, updated_at, position, discount_amount, final_price
 `
 
 type CreateBillItemParams struct {
-	ID        pgtype.UUID    `json:"id"`
-	BillID    pgtype.UUID    `json:"bill_id"`
-	GroupID   pgtype.UUID    `json:"group_id"`
-	Name      string         `json:"name"`
-	Quantity  pgtype.Numeric `json:"quantity"`
-	UnitPrice int64          `json:"unit_price"`
-	LineTotal int64          `json:"line_total"`
-	Position  int16          `json:"position"`
+	ID             pgtype.UUID    `json:"id"`
+	BillID         pgtype.UUID    `json:"bill_id"`
+	GroupID        pgtype.UUID    `json:"group_id"`
+	Name           string         `json:"name"`
+	Quantity       pgtype.Numeric `json:"quantity"`
+	UnitPrice      int64          `json:"unit_price"`
+	LineTotal      int64          `json:"line_total"`
+	DiscountAmount int64          `json:"discount_amount"`
+	FinalPrice     int64          `json:"final_price"`
+	Position       int16          `json:"position"`
 }
 
 // ============================================================================
@@ -227,6 +239,8 @@ func (q *Queries) CreateBillItem(ctx context.Context, arg CreateBillItemParams) 
 		arg.Quantity,
 		arg.UnitPrice,
 		arg.LineTotal,
+		arg.DiscountAmount,
+		arg.FinalPrice,
 		arg.Position,
 	)
 	var i BillItem
@@ -241,6 +255,8 @@ func (q *Queries) CreateBillItem(ctx context.Context, arg CreateBillItemParams) 
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Position,
+		&i.DiscountAmount,
+		&i.FinalPrice,
 	)
 	return i, err
 }
@@ -365,7 +381,7 @@ INSERT INTO debts (
     updated_at
 ) VALUES (
     $1, $2, $3, $4, $5, $6, 'awaiting', 0, now(), now()
-) RETURNING id, group_id, bill_id, debtor_member_id, creditor_member_id, amount, status, reminder_count, payment_id, created_at, settled_at, updated_at
+) RETURNING id, group_id, bill_id, debtor_member_id, creditor_member_id, amount, status, reminder_count, payment_id, created_at, settled_at, updated_at, voided_at
 `
 
 type CreateDebtParams struct {
@@ -400,6 +416,7 @@ func (q *Queries) CreateDebt(ctx context.Context, arg CreateDebtParams) (Debt, e
 		&i.CreatedAt,
 		&i.SettledAt,
 		&i.UpdatedAt,
+		&i.VoidedAt,
 	)
 	return i, err
 }
@@ -580,7 +597,7 @@ SET status = 'finalized',
     version = version + 1,
     updated_at = now()
 WHERE id = $1 AND group_id = $2 AND status = 'reviewed' AND version = $3
-RETURNING id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id
+RETURNING id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id, total_item_discount, general_discount
 `
 
 type FinalizeBillParams struct {
@@ -616,6 +633,8 @@ func (q *Queries) FinalizeBill(ctx context.Context, arg FinalizeBillParams) (Bil
 		&i.MismatchCodes,
 		&i.ReviewedAt,
 		&i.ReviewedByMemberID,
+		&i.TotalItemDiscount,
+		&i.GeneralDiscount,
 	)
 	return i, err
 }
@@ -647,7 +666,7 @@ func (q *Queries) GetActiveOCRJobByBillID(ctx context.Context, billID pgtype.UUI
 }
 
 const getBillByID = `-- name: GetBillByID :one
-SELECT id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id FROM bills
+SELECT id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id, total_item_discount, general_discount FROM bills
 WHERE id = $1 AND group_id = $2
 `
 
@@ -683,12 +702,14 @@ func (q *Queries) GetBillByID(ctx context.Context, arg GetBillByIDParams) (Bill,
 		&i.MismatchCodes,
 		&i.ReviewedAt,
 		&i.ReviewedByMemberID,
+		&i.TotalItemDiscount,
+		&i.GeneralDiscount,
 	)
 	return i, err
 }
 
 const getBillByIDForUpdate = `-- name: GetBillByIDForUpdate :one
-SELECT id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id FROM bills
+SELECT id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id, total_item_discount, general_discount FROM bills
 WHERE id = $1 AND group_id = $2
 FOR UPDATE
 `
@@ -725,6 +746,8 @@ func (q *Queries) GetBillByIDForUpdate(ctx context.Context, arg GetBillByIDForUp
 		&i.MismatchCodes,
 		&i.ReviewedAt,
 		&i.ReviewedByMemberID,
+		&i.TotalItemDiscount,
+		&i.GeneralDiscount,
 	)
 	return i, err
 }
@@ -1073,7 +1096,7 @@ func (q *Queries) ListBillItemAssignmentsByItem(ctx context.Context, billItemID 
 }
 
 const listBillItems = `-- name: ListBillItems :many
-SELECT id, bill_id, group_id, name, quantity, unit_price, line_total, created_at, updated_at, position FROM bill_items
+SELECT id, bill_id, group_id, name, quantity, unit_price, line_total, created_at, updated_at, position, discount_amount, final_price FROM bill_items
 WHERE bill_id = $1
 ORDER BY position ASC
 `
@@ -1098,6 +1121,8 @@ func (q *Queries) ListBillItems(ctx context.Context, billID pgtype.UUID) ([]Bill
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.Position,
+			&i.DiscountAmount,
+			&i.FinalPrice,
 		); err != nil {
 			return nil, err
 		}
@@ -1147,7 +1172,7 @@ func (q *Queries) ListBillShares(ctx context.Context, billID pgtype.UUID) ([]Bil
 }
 
 const listBillsByGroup = `-- name: ListBillsByGroup :many
-SELECT id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id FROM bills
+SELECT id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id, total_item_discount, general_discount FROM bills
 WHERE group_id = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
@@ -1192,6 +1217,8 @@ func (q *Queries) ListBillsByGroup(ctx context.Context, arg ListBillsByGroupPara
 			&i.MismatchCodes,
 			&i.ReviewedAt,
 			&i.ReviewedByMemberID,
+			&i.TotalItemDiscount,
+			&i.GeneralDiscount,
 		); err != nil {
 			return nil, err
 		}
@@ -1204,7 +1231,7 @@ func (q *Queries) ListBillsByGroup(ctx context.Context, arg ListBillsByGroupPara
 }
 
 const listBillsByGroupCursor = `-- name: ListBillsByGroupCursor :many
-SELECT id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id FROM bills
+SELECT id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id, total_item_discount, general_discount FROM bills
 WHERE group_id = $1
   AND (
     $2::timestamptz IS NULL 
@@ -1260,6 +1287,8 @@ func (q *Queries) ListBillsByGroupCursor(ctx context.Context, arg ListBillsByGro
 			&i.MismatchCodes,
 			&i.ReviewedAt,
 			&i.ReviewedByMemberID,
+			&i.TotalItemDiscount,
+			&i.GeneralDiscount,
 		); err != nil {
 			return nil, err
 		}
@@ -1272,7 +1301,7 @@ func (q *Queries) ListBillsByGroupCursor(ctx context.Context, arg ListBillsByGro
 }
 
 const listDebtsByBillIDForUpdate = `-- name: ListDebtsByBillIDForUpdate :many
-SELECT id, group_id, bill_id, debtor_member_id, creditor_member_id, amount, status, reminder_count, payment_id, created_at, settled_at, updated_at FROM debts
+SELECT id, group_id, bill_id, debtor_member_id, creditor_member_id, amount, status, reminder_count, payment_id, created_at, settled_at, updated_at, voided_at FROM debts
 WHERE bill_id = $1
 ORDER BY id ASC
 FOR UPDATE
@@ -1300,6 +1329,7 @@ func (q *Queries) ListDebtsByBillIDForUpdate(ctx context.Context, billID pgtype.
 			&i.CreatedAt,
 			&i.SettledAt,
 			&i.UpdatedAt,
+			&i.VoidedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1319,7 +1349,7 @@ SET status = 'reviewed',
     version = version + 1,
     updated_at = now()
 WHERE id = $1 AND group_id = $2 AND status = 'draft' AND version = $3
-RETURNING id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id
+RETURNING id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id, total_item_discount, general_discount
 `
 
 type ReviewBillParams struct {
@@ -1361,6 +1391,8 @@ func (q *Queries) ReviewBill(ctx context.Context, arg ReviewBillParams) (Bill, e
 		&i.MismatchCodes,
 		&i.ReviewedAt,
 		&i.ReviewedByMemberID,
+		&i.TotalItemDiscount,
+		&i.GeneralDiscount,
 	)
 	return i, err
 }
@@ -1373,31 +1405,35 @@ SET merchant_name = $3,
     service_charge = $6,
     vat = $7,
     discount = $8,
-    total = $9,
-    split_method = $10,
-    mismatch_codes = $11,
+    total_item_discount = $9,
+    general_discount = $10,
+    total = $11,
+    split_method = $12,
+    mismatch_codes = $13,
     status = 'draft',
     reviewed_at = NULL,
     reviewed_by_member_id = NULL,
     version = version + 1,
     updated_at = now()
-WHERE id = $1 AND group_id = $2 AND status IN ('draft', 'reviewed') AND version = $12
-RETURNING id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id
+WHERE id = $1 AND group_id = $2 AND status IN ('draft', 'reviewed') AND version = $14
+RETURNING id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id, total_item_discount, general_discount
 `
 
 type UpdateDraftBillParams struct {
-	ID            pgtype.UUID `json:"id"`
-	GroupID       pgtype.UUID `json:"group_id"`
-	MerchantName  pgtype.Text `json:"merchant_name"`
-	BillDate      pgtype.Date `json:"bill_date"`
-	Subtotal      int64       `json:"subtotal"`
-	ServiceCharge int64       `json:"service_charge"`
-	Vat           int64       `json:"vat"`
-	Discount      int64       `json:"discount"`
-	Total         int64       `json:"total"`
-	SplitMethod   string      `json:"split_method"`
-	MismatchCodes []string    `json:"mismatch_codes"`
-	Version       int32       `json:"version"`
+	ID                pgtype.UUID `json:"id"`
+	GroupID           pgtype.UUID `json:"group_id"`
+	MerchantName      pgtype.Text `json:"merchant_name"`
+	BillDate          pgtype.Date `json:"bill_date"`
+	Subtotal          int64       `json:"subtotal"`
+	ServiceCharge     int64       `json:"service_charge"`
+	Vat               int64       `json:"vat"`
+	Discount          int64       `json:"discount"`
+	TotalItemDiscount int64       `json:"total_item_discount"`
+	GeneralDiscount   int64       `json:"general_discount"`
+	Total             int64       `json:"total"`
+	SplitMethod       string      `json:"split_method"`
+	MismatchCodes     []string    `json:"mismatch_codes"`
+	Version           int32       `json:"version"`
 }
 
 func (q *Queries) UpdateDraftBill(ctx context.Context, arg UpdateDraftBillParams) (Bill, error) {
@@ -1410,6 +1446,8 @@ func (q *Queries) UpdateDraftBill(ctx context.Context, arg UpdateDraftBillParams
 		arg.ServiceCharge,
 		arg.Vat,
 		arg.Discount,
+		arg.TotalItemDiscount,
+		arg.GeneralDiscount,
 		arg.Total,
 		arg.SplitMethod,
 		arg.MismatchCodes,
@@ -1440,6 +1478,8 @@ func (q *Queries) UpdateDraftBill(ctx context.Context, arg UpdateDraftBillParams
 		&i.MismatchCodes,
 		&i.ReviewedAt,
 		&i.ReviewedByMemberID,
+		&i.TotalItemDiscount,
+		&i.GeneralDiscount,
 	)
 	return i, err
 }
@@ -1552,7 +1592,7 @@ SET status = 'voided',
     version = version + 1,
     updated_at = now()
 WHERE id = $1 AND group_id = $2 AND status = 'finalized' AND version = $3
-RETURNING id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id
+RETURNING id, group_id, creditor_member_id, status, merchant_name, bill_date, image_object_key, subtotal, service_charge, vat, discount, total, mismatch_warning, version, created_at, finalized_at, updated_at, replaces_bill_id, voided_at, split_method, mismatch_codes, reviewed_at, reviewed_by_member_id, total_item_discount, general_discount
 `
 
 type VoidBillParams struct {
@@ -1588,6 +1628,8 @@ func (q *Queries) VoidBill(ctx context.Context, arg VoidBillParams) (Bill, error
 		&i.MismatchCodes,
 		&i.ReviewedAt,
 		&i.ReviewedByMemberID,
+		&i.TotalItemDiscount,
+		&i.GeneralDiscount,
 	)
 	return i, err
 }

--- a/internal/modules/bill/repository/postgres/sqlc/models.go
+++ b/internal/modules/bill/repository/postgres/sqlc/models.go
@@ -49,6 +49,8 @@ type Bill struct {
 	MismatchCodes      []string           `json:"mismatch_codes"`
 	ReviewedAt         pgtype.Timestamptz `json:"reviewed_at"`
 	ReviewedByMemberID pgtype.UUID        `json:"reviewed_by_member_id"`
+	TotalItemDiscount  int64              `json:"total_item_discount"`
+	GeneralDiscount    int64              `json:"general_discount"`
 }
 
 type BillIdempotencyKey struct {
@@ -77,16 +79,18 @@ type BillImage struct {
 }
 
 type BillItem struct {
-	ID        pgtype.UUID        `json:"id"`
-	BillID    pgtype.UUID        `json:"bill_id"`
-	GroupID   pgtype.UUID        `json:"group_id"`
-	Name      string             `json:"name"`
-	Quantity  pgtype.Numeric     `json:"quantity"`
-	UnitPrice int64              `json:"unit_price"`
-	LineTotal int64              `json:"line_total"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
-	Position  int16              `json:"position"`
+	ID             pgtype.UUID        `json:"id"`
+	BillID         pgtype.UUID        `json:"bill_id"`
+	GroupID        pgtype.UUID        `json:"group_id"`
+	Name           string             `json:"name"`
+	Quantity       pgtype.Numeric     `json:"quantity"`
+	UnitPrice      int64              `json:"unit_price"`
+	LineTotal      int64              `json:"line_total"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+	Position       int16              `json:"position"`
+	DiscountAmount int64              `json:"discount_amount"`
+	FinalPrice     int64              `json:"final_price"`
 }
 
 type BillItemAssignment struct {
@@ -125,6 +129,7 @@ type Debt struct {
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	SettledAt        pgtype.Timestamptz `json:"settled_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	VoidedAt         pgtype.Timestamptz `json:"voided_at"`
 }
 
 type Group struct {

--- a/internal/modules/bill/usecase/reconciliation_internal_test.go
+++ b/internal/modules/bill/usecase/reconciliation_internal_test.go
@@ -22,12 +22,21 @@ func billFixture(creditor uuid.UUID, items []*domain.BillItem, subtotal, sc, vat
 }
 
 func itemFixture(lineTotal int64, memberIDs ...uuid.UUID) *domain.BillItem {
-	it := &domain.BillItem{ID: uuid.New(), LineTotal: lineTotal}
+	it := &domain.BillItem{ID: uuid.New(), LineTotal: lineTotal, FinalPrice: lineTotal}
 	for _, m := range memberIDs {
 		it.Assignments = append(it.Assignments, &domain.BillItemAssignment{
 			ID: uuid.New(), MemberID: m, Weight: "1.0000",
 		})
 	}
+	return it
+}
+
+// discountedItemFixture là itemFixture với khuyến mãi riêng theo món đã gộp (Spec 3 AC-15, AC-17):
+// finalPrice = lineTotal - discountAmount.
+func discountedItemFixture(lineTotal, discountAmount int64, memberIDs ...uuid.UUID) *domain.BillItem {
+	it := itemFixture(lineTotal, memberIDs...)
+	it.DiscountAmount = discountAmount
+	it.FinalPrice = lineTotal - discountAmount
 	return it
 }
 
@@ -126,6 +135,51 @@ func TestEvaluateAllocation_MissingCreditor(t *testing.T) {
 
 	if _, blockers := evaluateAllocation(bill, map[uuid.UUID]bool{m: true}); !hasCode(blockers, BlockerCreditorRequired) {
 		t.Fatalf("mong đợi %s, nhận %v", BlockerCreditorRequired, blockers)
+	}
+}
+
+// TestEvaluateAllocation_ItemDiscountStaysWithAssignee khớp Spec 3 AC-17: khuyến mãi gắn riêng cho
+// một món chỉ được lợi cho đúng thành viên được gán món đó, không bị chia đều cho cả nhóm như
+// giảm giá chung. Tái hiện đúng lỗi gốc đã sửa: toAllocationInput từng truyền LineTotal (giá gốc)
+// và Discount gộp cả khoản khuyến mãi theo món, khiến khuyến mãi bị rải đều cho mọi thành viên.
+func TestEvaluateAllocation_ItemDiscountStaysWithAssignee(t *testing.T) {
+	creditor, other := uuid.New(), uuid.New()
+
+	// Món của creditor: 100.000đ, khuyến mãi riêng 20.000đ -> final_price 80.000đ.
+	itemWithDiscount := discountedItemFixture(100000, 20000, creditor)
+	// Món của other: 50.000đ, không khuyến mãi.
+	itemPlain := itemFixture(50000, other)
+
+	bill := &domain.Bill{
+		ID:                uuid.New(),
+		CreditorMemberID:  creditor,
+		Subtotal:          150000, // tổng gộp trước khuyến mãi: 100000 + 50000
+		TotalItemDiscount: 20000,
+		GeneralDiscount:   0,
+		Discount:          20000, // = TotalItemDiscount + GeneralDiscount
+		Total:             130000,
+		Items:             []*domain.BillItem{itemWithDiscount, itemPlain},
+	}
+
+	allocs, blockers := evaluateAllocation(bill, map[uuid.UUID]bool{creditor: true, other: true})
+	if len(blockers) != 0 {
+		t.Fatalf("mong đợi không có mã chặn, nhận %v", blockers)
+	}
+
+	byMember := make(map[uuid.UUID]*MemberAllocation, len(allocs))
+	for _, a := range allocs {
+		byMember[a.MemberID] = a
+	}
+
+	// other không dính món có khuyến mãi nên phải trả đủ 50.000đ, không được hưởng một phần của
+	// khoản giảm giá 20.000đ dành cho món của creditor.
+	if got := byMember[other].FinalAmount; got != 50000 {
+		t.Errorf("other phải trả đủ 50000 (không chia sẻ khuyến mãi của món khác), nhận %d", got)
+	}
+	// creditor nhận phần còn lại: net_items_total (130000) - other (50000) = 80000, đúng bằng
+	// final_price của món creditor.
+	if got := byMember[creditor].FinalAmount; got != 80000 {
+		t.Errorf("creditor phải chỉ còn 80000 sau khuyến mãi riêng của món, nhận %d", got)
 	}
 }
 

--- a/internal/modules/bill/usecase/service.go
+++ b/internal/modules/bill/usecase/service.go
@@ -92,11 +92,15 @@ func (s *Service) SetManualOCRConfig(limit int, window time.Duration) {
 // ============================================================================
 
 type CreateBillItemRequest struct {
-	Name        string                        `json:"name"`
-	Quantity    string                        `json:"quantity"`
-	UnitPrice   int64                         `json:"unit_price"`
-	LineTotal   int64                         `json:"line_total"`
-	Assignments []CreateItemAssignmentRequest `json:"assignments"`
+	Name      string `json:"name"`
+	Quantity  string `json:"quantity"`
+	UnitPrice int64  `json:"unit_price"`
+	LineTotal int64  `json:"line_total"`
+	// DiscountAmount là khuyến mãi riêng theo món (VND), mặc định 0 khi không gửi lên.
+	// Máy chủ tự tính lại final_price và tổng hợp total_item_discount, không nhận final_price
+	// trực tiếp từ client (Spec 3 AC-19, AC-20).
+	DiscountAmount int64                         `json:"discount_amount"`
+	Assignments    []CreateItemAssignmentRequest `json:"assignments"`
 }
 
 type CreateItemAssignmentRequest struct {
@@ -166,6 +170,11 @@ func (s *Service) CreateBill(ctx context.Context, callerUserID uuid.UUID, req Cr
 	if len(req.Items) > 100 {
 		return nil, fmt.Errorf("%w: maximum 100 items allowed", domain.ErrInvalidInput)
 	}
+	// Spec 3 AC-21: CreateBill trước đây không có kiểm tra này, khiến discount > 0 vi phạm
+	// check_bills_discount_composition ở tầng database và trả về lỗi 500 không kiểm soát.
+	if req.Discount < 0 {
+		return nil, fmt.Errorf("%w: discount must not be negative", domain.ErrInvalidInput)
+	}
 
 	// Kiểm tra tính hợp lệ của replaces_bill_id nếu được truyền (Spec 3 AC-11)
 	if req.ReplacesBillID != nil && *req.ReplacesBillID != uuid.Nil {
@@ -178,16 +187,6 @@ func (s *Service) CreateBill(ctx context.Context, callerUserID uuid.UUID, req Cr
 		}
 		if replacedBill.Status != domain.BillStatusVoided {
 			return nil, fmt.Errorf("%w: replaced bill must be voided", domain.ErrInvalidInput)
-		}
-	}
-
-	// Kiểm tra tính hợp lệ của trọng số assignments
-	for _, it := range req.Items {
-		for _, assign := range it.Assignments {
-			w, err := strconv.ParseFloat(assign.Weight, 64)
-			if err != nil || w <= 0 || math.IsNaN(w) || math.IsInf(w, 0) {
-				return nil, fmt.Errorf("%w: assignment weight must be a positive number", domain.ErrInvalidInput)
-			}
 		}
 	}
 
@@ -228,36 +227,57 @@ func (s *Service) CreateBill(ctx context.Context, callerUserID uuid.UUID, req Cr
 		})
 	}
 
-	// 3. Chuẩn bị danh sách món ăn
+	// 3. Chuẩn bị danh sách món ăn, kiểm tra discount_amount theo từng món (Spec 3 AC-19, AC-20, AC-21)
 	items := make([]*domain.BillItem, 0, len(req.Items))
+	var totalItemDiscount int64
 	for i, it := range req.Items {
 		itemID := uuid.Must(uuid.NewV7())
 		lineTotal := it.LineTotal
 		if lineTotal == 0 && it.UnitPrice > 0 {
 			lineTotal = computeLineTotal(it.UnitPrice, it.Quantity)
 		}
-
-		domItem := &domain.BillItem{
-			ID:        itemID,
-			BillID:    billID,
-			GroupID:   req.GroupID,
-			Name:      it.Name,
-			Quantity:  it.Quantity,
-			UnitPrice: it.UnitPrice,
-			LineTotal: lineTotal,
-			Position:  int16(i),
+		if lineTotal < 0 {
+			return nil, fmt.Errorf("%w: item %d: line_total must not be negative", domain.ErrInvalidInput, i)
 		}
+		if it.DiscountAmount < 0 || it.DiscountAmount > lineTotal {
+			return nil, fmt.Errorf("%w: item %d: discount_amount must be between 0 and line_total", domain.ErrInvalidInput, i)
+		}
+		totalItemDiscount += it.DiscountAmount
 
+		items = append(items, &domain.BillItem{
+			ID:             itemID,
+			BillID:         billID,
+			GroupID:        req.GroupID,
+			Name:           it.Name,
+			Quantity:       it.Quantity,
+			UnitPrice:      it.UnitPrice,
+			LineTotal:      lineTotal,
+			DiscountAmount: it.DiscountAmount,
+			FinalPrice:     lineTotal - it.DiscountAmount,
+			Position:       int16(i),
+		})
+	}
+
+	generalDiscount := req.Discount - totalItemDiscount
+	if generalDiscount < 0 {
+		return nil, fmt.Errorf("%w: discount is less than the sum of item discounts", domain.ErrInvalidInput)
+	}
+
+	// Kiểm tra tính hợp lệ của trọng số assignments, sau khi discount đã hợp lệ (Spec 3 AC-19)
+	for i, it := range req.Items {
 		for _, assign := range it.Assignments {
-			domItem.Assignments = append(domItem.Assignments, &domain.BillItemAssignment{
+			w, err := strconv.ParseFloat(assign.Weight, 64)
+			if err != nil || w <= 0 || math.IsNaN(w) || math.IsInf(w, 0) {
+				return nil, fmt.Errorf("%w: assignment weight must be a positive number", domain.ErrInvalidInput)
+			}
+			items[i].Assignments = append(items[i].Assignments, &domain.BillItemAssignment{
 				ID:         uuid.Must(uuid.NewV7()),
-				BillItemID: itemID,
+				BillItemID: items[i].ID,
 				GroupID:    req.GroupID,
 				MemberID:   assign.MemberID,
 				Weight:     assign.Weight,
 			})
 		}
-		items = append(items, domItem)
 	}
 
 	// 4. Chuẩn bị Bill domain entity
@@ -267,20 +287,22 @@ func (s *Service) CreateBill(ctx context.Context, callerUserID uuid.UUID, req Cr
 	}
 
 	bill := &domain.Bill{
-		ID:               billID,
-		GroupID:          req.GroupID,
-		CreditorMemberID: member.ID,
-		MerchantName:     req.MerchantName,
-		BillDate:         req.BillDate,
-		Subtotal:         req.Subtotal,
-		ServiceCharge:    req.ServiceCharge,
-		VAT:              req.VAT,
-		Discount:         req.Discount,
-		Total:            req.Total,
-		SplitMethod:      splitMethod,
-		ReplacesBillID:   req.ReplacesBillID,
-		Status:           domain.BillStatusDraft,
-		Version:          1,
+		ID:                billID,
+		GroupID:           req.GroupID,
+		CreditorMemberID:  member.ID,
+		MerchantName:      req.MerchantName,
+		BillDate:          req.BillDate,
+		Subtotal:          req.Subtotal,
+		ServiceCharge:     req.ServiceCharge,
+		VAT:               req.VAT,
+		Discount:          req.Discount,
+		TotalItemDiscount: totalItemDiscount,
+		GeneralDiscount:   generalDiscount,
+		Total:             req.Total,
+		SplitMethod:       splitMethod,
+		ReplacesBillID:    req.ReplacesBillID,
+		Status:            domain.BillStatusDraft,
+		Version:           1,
 	}
 
 	// 5. Nếu có ảnh -> tạo kèm OCRJob (Spec 3 AC-2)
@@ -537,6 +559,8 @@ func (s *Service) ApplyCandidate(ctx context.Context, callerUserID, billID, grou
 	bill.ServiceCharge = candidate.ServiceCharge
 	bill.VAT = candidate.VAT
 	bill.Discount = candidate.Discount
+	bill.TotalItemDiscount = candidate.TotalItemDiscount
+	bill.GeneralDiscount = candidate.GeneralDiscount
 	bill.Total = candidate.Total
 	bill.MismatchCodes = candidate.Warnings
 
@@ -545,14 +569,16 @@ func (s *Service) ApplyCandidate(ctx context.Context, callerUserID, billID, grou
 	for i, cItem := range candidate.Items {
 		itemID := uuid.Must(uuid.NewV7())
 		domItem := &domain.BillItem{
-			ID:        itemID,
-			BillID:    billID,
-			GroupID:   groupID,
-			Name:      cItem.Name,
-			Quantity:  cItem.Quantity,
-			UnitPrice: cItem.UnitPrice,
-			LineTotal: cItem.LineTotal,
-			Position:  int16(i),
+			ID:             itemID,
+			BillID:         billID,
+			GroupID:        groupID,
+			Name:           cItem.Name,
+			Quantity:       cItem.Quantity,
+			UnitPrice:      cItem.UnitPrice,
+			LineTotal:      cItem.LineTotal,
+			DiscountAmount: cItem.DiscountAmount,
+			FinalPrice:     cItem.FinalPrice,
+			Position:       int16(i),
 		}
 
 		// Gán chia đều mặc định cho toàn bộ thành viên nhóm
@@ -607,16 +633,59 @@ func (s *Service) UpdateDraftBill(ctx context.Context, callerUserID, billID, gro
 
 	// Kiểm tra giá trị discount không được âm
 	if req.Discount < 0 {
-		return nil, domain.ErrInvalidInput
+		return nil, fmt.Errorf("%w: discount must not be negative", domain.ErrInvalidInput)
 	}
 
-	// Kiểm tra tính hợp lệ của trọng số assignments
-	for _, it := range req.Items {
+	// Chuẩn bị danh sách món ăn, kiểm tra discount_amount theo từng món (Spec 3 AC-19)
+	items := make([]*domain.BillItem, 0, len(req.Items))
+	var totalItemDiscount int64
+	for i, it := range req.Items {
+		itemID := uuid.Must(uuid.NewV7())
+		lineTotal := it.LineTotal
+		if lineTotal == 0 && it.UnitPrice > 0 {
+			lineTotal = computeLineTotal(it.UnitPrice, it.Quantity)
+		}
+		if lineTotal < 0 {
+			return nil, fmt.Errorf("%w: item %d: line_total must not be negative", domain.ErrInvalidInput, i)
+		}
+		if it.DiscountAmount < 0 || it.DiscountAmount > lineTotal {
+			return nil, fmt.Errorf("%w: item %d: discount_amount must be between 0 and line_total", domain.ErrInvalidInput, i)
+		}
+		totalItemDiscount += it.DiscountAmount
+
+		items = append(items, &domain.BillItem{
+			ID:             itemID,
+			BillID:         billID,
+			GroupID:        groupID,
+			Name:           it.Name,
+			Quantity:       it.Quantity,
+			UnitPrice:      it.UnitPrice,
+			LineTotal:      lineTotal,
+			DiscountAmount: it.DiscountAmount,
+			FinalPrice:     lineTotal - it.DiscountAmount,
+			Position:       int16(i),
+		})
+	}
+
+	generalDiscount := req.Discount - totalItemDiscount
+	if generalDiscount < 0 {
+		return nil, fmt.Errorf("%w: discount is less than the sum of item discounts", domain.ErrInvalidInput)
+	}
+
+	// Kiểm tra tính hợp lệ của trọng số assignments, sau khi discount đã hợp lệ (Spec 3 AC-19)
+	for i, it := range req.Items {
 		for _, assign := range it.Assignments {
 			w, err := strconv.ParseFloat(assign.Weight, 64)
 			if err != nil || w <= 0 || math.IsNaN(w) || math.IsInf(w, 0) {
 				return nil, fmt.Errorf("%w: assignment weight must be a positive number", domain.ErrInvalidInput)
 			}
+			items[i].Assignments = append(items[i].Assignments, &domain.BillItemAssignment{
+				ID:         uuid.Must(uuid.NewV7()),
+				BillItemID: items[i].ID,
+				GroupID:    groupID,
+				MemberID:   assign.MemberID,
+				Weight:     assign.Weight,
+			})
 		}
 	}
 
@@ -626,39 +695,10 @@ func (s *Service) UpdateDraftBill(ctx context.Context, callerUserID, billID, gro
 	bill.ServiceCharge = req.ServiceCharge
 	bill.VAT = req.VAT
 	bill.Discount = req.Discount
+	bill.TotalItemDiscount = totalItemDiscount
+	bill.GeneralDiscount = generalDiscount
 	bill.Total = req.Total
 	bill.SplitMethod = req.SplitMethod
-
-	items := make([]*domain.BillItem, 0, len(req.Items))
-	for i, it := range req.Items {
-		itemID := uuid.Must(uuid.NewV7())
-		lineTotal := it.LineTotal
-		if lineTotal == 0 && it.UnitPrice > 0 {
-			lineTotal = computeLineTotal(it.UnitPrice, it.Quantity)
-		}
-
-		domItem := &domain.BillItem{
-			ID:        itemID,
-			BillID:    billID,
-			GroupID:   groupID,
-			Name:      it.Name,
-			Quantity:  it.Quantity,
-			UnitPrice: it.UnitPrice,
-			LineTotal: lineTotal,
-			Position:  int16(i),
-		}
-
-		for _, assign := range it.Assignments {
-			domItem.Assignments = append(domItem.Assignments, &domain.BillItemAssignment{
-				ID:         uuid.Must(uuid.NewV7()),
-				BillItemID: itemID,
-				GroupID:    groupID,
-				MemberID:   assign.MemberID,
-				Weight:     assign.Weight,
-			})
-		}
-		items = append(items, domItem)
-	}
 
 	return s.repo.UpdateDraftBill(ctx, repository.UpdateDraftParams{
 		Bill:            bill,
@@ -959,8 +999,10 @@ func toAllocationInput(b *domain.Bill) AllocationInput {
 		}
 
 		items = append(items, ItemInput{
-			ID:          it.ID,
-			LineTotal:   it.LineTotal,
+			ID: it.ID,
+			// Dùng FinalPrice (giá đã trừ khuyến mãi riêng của món) chứ không phải LineTotal (giá gốc),
+			// để khuyến mãi theo món chỉ có lợi cho đúng người được gán món đó (Spec 3 AC-17).
+			LineTotal:   it.FinalPrice,
 			Assignments: assigns,
 		})
 	}
@@ -970,9 +1012,11 @@ func toAllocationInput(b *domain.Bill) AllocationInput {
 		Subtotal:      b.Subtotal,
 		ServiceCharge: b.ServiceCharge,
 		VAT:           b.VAT,
-		Discount:      b.Discount,
-		Total:         b.Total,
-		Items:         items,
+		// Chỉ phân bổ giảm giá chung theo tỷ lệ; giảm giá riêng theo món đã nằm sẵn trong FinalPrice
+		// ở trên nên không được cộng dồn lại ở đây (Spec 3 AC-17, AC-18).
+		Discount: b.GeneralDiscount,
+		Total:    b.Total,
+		Items:    items,
 	}
 }
 

--- a/internal/modules/bill/usecase/service_test.go
+++ b/internal/modules/bill/usecase/service_test.go
@@ -3,6 +3,7 @@ package usecase_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -1900,5 +1901,391 @@ func TestCheckOrReserveIdempotency_NilRecord_ReturnsErrorNotPanic(t *testing.T) 
 	}
 	if !errors.Is(err, domain.ErrIdempotencyInProgress) {
 		t.Fatalf("mong đợi ErrIdempotencyInProgress, nhận %v", err)
+	}
+}
+
+// TestCreateBill_ItemDiscount_ComputesFinalPriceAndTotals khớp Spec 3 AC-20: POST /bills nhận
+// discount_amount theo món, tự tính final_price và total_item_discount/general_discount.
+func TestCreateBill_ItemDiscount_ComputesFinalPriceAndTotals(t *testing.T) {
+	groupID := uuid.New()
+	userID := uuid.New()
+	captainMemberID := uuid.New()
+
+	repo := &mockServiceRepo{
+		member: &repository.GroupMember{
+			ID:      captainMemberID,
+			GroupID: groupID,
+			UserID:  userID,
+			Role:    "captain",
+			Status:  "active",
+		},
+	}
+
+	service := usecase.NewService(repo, &mockOCRProvider{}, &mockStorage{}, &mockProcessor{}, &mockEnqueuer{})
+
+	res, err := service.CreateBill(context.Background(), userID, usecase.CreateBillRequest{
+		GroupID:  groupID,
+		Discount: 80000, // 50000 theo món (Bò bít tết) + 30000 giảm giá chung
+		Total:    170000,
+		Items: []usecase.CreateBillItemRequest{
+			{
+				Name:           "Bò bít tết",
+				LineTotal:      250000,
+				DiscountAmount: 50000,
+				Assignments: []usecase.CreateItemAssignmentRequest{
+					{MemberID: captainMemberID, Weight: "1"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBill() unexpected error = %v", err)
+	}
+	if len(res.Bill.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(res.Bill.Items))
+	}
+	item := res.Bill.Items[0]
+	if item.DiscountAmount != 50000 || item.FinalPrice != 200000 {
+		t.Errorf("expected discount_amount 50000 and final_price 200000, got %d/%d", item.DiscountAmount, item.FinalPrice)
+	}
+	if res.Bill.TotalItemDiscount != 50000 {
+		t.Errorf("expected total_item_discount 50000, got %d", res.Bill.TotalItemDiscount)
+	}
+	if res.Bill.GeneralDiscount != 30000 {
+		t.Errorf("expected general_discount 30000, got %d", res.Bill.GeneralDiscount)
+	}
+}
+
+// TestCreateBill_ItemDiscountExceedsLineTotal_ReturnsInvalidInput khớp Spec 3 AC-19/AC-20: validate
+// discount_amount dựa trên line_total đã suy ra (unit_price × quantity), không phải giá trị thô.
+func TestCreateBill_ItemDiscountExceedsLineTotal_ReturnsInvalidInput(t *testing.T) {
+	groupID := uuid.New()
+	userID := uuid.New()
+	captainMemberID := uuid.New()
+
+	repo := &mockServiceRepo{
+		member: &repository.GroupMember{
+			ID:      captainMemberID,
+			GroupID: groupID,
+			UserID:  userID,
+			Role:    "captain",
+			Status:  "active",
+		},
+	}
+
+	service := usecase.NewService(repo, &mockOCRProvider{}, &mockStorage{}, &mockProcessor{}, &mockEnqueuer{})
+
+	_, err := service.CreateBill(context.Background(), userID, usecase.CreateBillRequest{
+		GroupID: groupID,
+		Total:   0,
+		Items: []usecase.CreateBillItemRequest{
+			{
+				// line_total gửi lên là 0, nhưng giá trị dùng để validate phải là giá trị suy ra
+				// 100000 x 2 = 200000, nên discount_amount 250000 phải bị từ chối.
+				Name:           "Trà sữa",
+				LineTotal:      0,
+				UnitPrice:      100000,
+				Quantity:       "2",
+				DiscountAmount: 250000,
+				Assignments: []usecase.CreateItemAssignmentRequest{
+					{MemberID: captainMemberID, Weight: "1"},
+				},
+			},
+		},
+	})
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Errorf("expected ErrInvalidInput for discount_amount exceeding derived line_total, got %v", err)
+	}
+}
+
+// TestCreateBill_DiscountCompositionBug_NoLongerFails khớp Spec 3 AC-21: trước đây CreateBill
+// không set total_item_discount/general_discount, khiến discount > 0 vi phạm
+// check_bills_discount_composition ở tầng database (500 không kiểm soát trên DB thật). Ở tầng
+// usecase, hồi quy được xác nhận qua việc general_discount giờ được tính đúng thay vì bỏ trống.
+func TestCreateBill_DiscountCompositionBug_NoLongerFails(t *testing.T) {
+	groupID := uuid.New()
+	userID := uuid.New()
+	captainMemberID := uuid.New()
+
+	repo := &mockServiceRepo{
+		member: &repository.GroupMember{
+			ID:      captainMemberID,
+			GroupID: groupID,
+			UserID:  userID,
+			Role:    "captain",
+			Status:  "active",
+		},
+	}
+
+	service := usecase.NewService(repo, &mockOCRProvider{}, &mockStorage{}, &mockProcessor{}, &mockEnqueuer{})
+
+	res, err := service.CreateBill(context.Background(), userID, usecase.CreateBillRequest{
+		GroupID:  groupID,
+		Discount: 20000,
+		Total:    30000,
+		Items: []usecase.CreateBillItemRequest{
+			{
+				Name:      "Cà phê",
+				LineTotal: 50000,
+				Assignments: []usecase.CreateItemAssignmentRequest{
+					{MemberID: captainMemberID, Weight: "1"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBill() unexpected error = %v", err)
+	}
+	if res.Bill.TotalItemDiscount != 0 {
+		t.Errorf("expected total_item_discount 0, got %d", res.Bill.TotalItemDiscount)
+	}
+	if res.Bill.GeneralDiscount != 20000 {
+		t.Errorf("expected general_discount 20000 (= discount, no item discount), got %d", res.Bill.GeneralDiscount)
+	}
+	if res.Bill.Discount != res.Bill.TotalItemDiscount+res.Bill.GeneralDiscount {
+		t.Errorf("discount composition invariant broken: discount=%d, total_item_discount=%d, general_discount=%d",
+			res.Bill.Discount, res.Bill.TotalItemDiscount, res.Bill.GeneralDiscount)
+	}
+}
+
+// TestUpdateDraftBill_ItemDiscount_RoundTrips khớp Spec 3 AC-19: PUT /bills/{id} nhận lại
+// discount_amount theo món khi người dùng gán lại (reassign) món cho đúng thành viên, không còn
+// bị quy hết về general_discount như hành vi cũ.
+func TestUpdateDraftBill_ItemDiscount_RoundTrips(t *testing.T) {
+	groupID := uuid.New()
+	userID := uuid.New()
+	captainMemberID := uuid.New()
+	member2ID := uuid.New()
+	billID := uuid.New()
+
+	repo := &mockServiceRepo{
+		member: &repository.GroupMember{
+			ID:      captainMemberID,
+			GroupID: groupID,
+			UserID:  userID,
+			Role:    "captain",
+			Status:  "active",
+		},
+		bill: &domain.Bill{
+			ID:               billID,
+			GroupID:          groupID,
+			CreditorMemberID: captainMemberID,
+			Status:           domain.BillStatusDraft,
+			Version:          1,
+		},
+	}
+
+	service := usecase.NewService(repo, &mockOCRProvider{}, &mockStorage{}, &mockProcessor{}, &mockEnqueuer{})
+
+	updated, err := service.UpdateDraftBill(context.Background(), userID, billID, groupID, usecase.UpdateDraftRequest{
+		Version:  1,
+		Discount: 50000,
+		Total:    200000,
+		Items: []usecase.CreateBillItemRequest{
+			{
+				Name:           "Bò bít tết",
+				LineTotal:      250000,
+				DiscountAmount: 50000,
+				Assignments: []usecase.CreateItemAssignmentRequest{
+					{MemberID: captainMemberID, Weight: "1"}, // gán lại cho creditor thay vì chia đều
+				},
+			},
+			{
+				Name:      "Nước ngọt",
+				LineTotal: 30000,
+				Assignments: []usecase.CreateItemAssignmentRequest{
+					{MemberID: member2ID, Weight: "1"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateDraftBill() unexpected error = %v", err)
+	}
+	if updated.TotalItemDiscount != 50000 {
+		t.Errorf("expected total_item_discount 50000 to survive the manual edit, got %d", updated.TotalItemDiscount)
+	}
+	if updated.GeneralDiscount != 0 {
+		t.Errorf("expected general_discount 0, got %d", updated.GeneralDiscount)
+	}
+	if len(updated.Items) != 2 || updated.Items[0].FinalPrice != 200000 {
+		t.Fatalf("expected item 0 final_price 200000, got %+v", updated.Items)
+	}
+}
+
+// TestCreateBill_NegativeItemDiscount_ReturnsInvalidInput khớp Spec 3 AC-19/AC-20: discount_amount
+// âm phải bị từ chối, không chỉ trường hợp vượt line_total.
+func TestCreateBill_NegativeItemDiscount_ReturnsInvalidInput(t *testing.T) {
+	groupID := uuid.New()
+	userID := uuid.New()
+	captainMemberID := uuid.New()
+
+	repo := &mockServiceRepo{
+		member: &repository.GroupMember{
+			ID:      captainMemberID,
+			GroupID: groupID,
+			UserID:  userID,
+			Role:    "captain",
+			Status:  "active",
+		},
+	}
+
+	service := usecase.NewService(repo, &mockOCRProvider{}, &mockStorage{}, &mockProcessor{}, &mockEnqueuer{})
+
+	_, err := service.CreateBill(context.Background(), userID, usecase.CreateBillRequest{
+		GroupID: groupID,
+		Total:   50000,
+		Items: []usecase.CreateBillItemRequest{
+			{
+				Name:           "Item 1",
+				LineTotal:      50000,
+				DiscountAmount: -1,
+				Assignments: []usecase.CreateItemAssignmentRequest{
+					{MemberID: captainMemberID, Weight: "1"},
+				},
+			},
+		},
+	})
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Errorf("expected ErrInvalidInput for negative discount_amount, got %v", err)
+	}
+}
+
+// TestCreateBill_ItemDiscount_ErrorIdentifiesFailingItemIndex khớp Spec 3 AC-19: thông báo lỗi
+// phải chỉ đúng item nào sai khi có nhiều món, không phải luôn báo item 0.
+func TestCreateBill_ItemDiscount_ErrorIdentifiesFailingItemIndex(t *testing.T) {
+	groupID := uuid.New()
+	userID := uuid.New()
+	captainMemberID := uuid.New()
+
+	repo := &mockServiceRepo{
+		member: &repository.GroupMember{
+			ID:      captainMemberID,
+			GroupID: groupID,
+			UserID:  userID,
+			Role:    "captain",
+			Status:  "active",
+		},
+	}
+
+	service := usecase.NewService(repo, &mockOCRProvider{}, &mockStorage{}, &mockProcessor{}, &mockEnqueuer{})
+
+	_, err := service.CreateBill(context.Background(), userID, usecase.CreateBillRequest{
+		GroupID: groupID,
+		Total:   80000,
+		Items: []usecase.CreateBillItemRequest{
+			{
+				Name:      "Item hợp lệ",
+				LineTotal: 30000,
+				Assignments: []usecase.CreateItemAssignmentRequest{
+					{MemberID: captainMemberID, Weight: "1"},
+				},
+			},
+			{
+				// Món thứ hai (index 1) mới là món sai, thông báo lỗi phải nêu đúng index này.
+				Name:           "Item lỗi",
+				LineTotal:      50000,
+				DiscountAmount: 999999,
+				Assignments: []usecase.CreateItemAssignmentRequest{
+					{MemberID: captainMemberID, Weight: "1"},
+				},
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "item 1") {
+		t.Errorf("expected error message to identify item 1 as the failing item, got %v", err)
+	}
+}
+
+// TestUpdateDraftBill_ItemDiscountExceedsLineTotal_ReturnsInvalidInput khớp Spec 3 AC-19: PUT
+// cũng phải áp dụng đúng validate discount_amount theo món như POST.
+func TestUpdateDraftBill_ItemDiscountExceedsLineTotal_ReturnsInvalidInput(t *testing.T) {
+	groupID := uuid.New()
+	userID := uuid.New()
+	captainMemberID := uuid.New()
+	billID := uuid.New()
+
+	repo := &mockServiceRepo{
+		member: &repository.GroupMember{
+			ID:      captainMemberID,
+			GroupID: groupID,
+			UserID:  userID,
+			Role:    "captain",
+			Status:  "active",
+		},
+		bill: &domain.Bill{
+			ID:               billID,
+			GroupID:          groupID,
+			CreditorMemberID: captainMemberID,
+			Status:           domain.BillStatusDraft,
+			Version:          1,
+		},
+	}
+
+	service := usecase.NewService(repo, &mockOCRProvider{}, &mockStorage{}, &mockProcessor{}, &mockEnqueuer{})
+
+	_, err := service.UpdateDraftBill(context.Background(), userID, billID, groupID, usecase.UpdateDraftRequest{
+		Version: 1,
+		Total:   0,
+		Items: []usecase.CreateBillItemRequest{
+			{
+				Name:           "Item lỗi",
+				LineTotal:      50000,
+				DiscountAmount: 60000,
+				Assignments: []usecase.CreateItemAssignmentRequest{
+					{MemberID: captainMemberID, Weight: "1"},
+				},
+			},
+		},
+	})
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Errorf("expected ErrInvalidInput for discount_amount exceeding line_total in UpdateDraftBill, got %v", err)
+	}
+}
+
+// TestUpdateDraftBill_GeneralDiscountNegative_ReturnsInvalidInput khớp Spec 3 AC-19: nếu tổng
+// discount_amount theo món vượt quá bill.discount khai báo, general_discount âm phải bị từ chối.
+func TestUpdateDraftBill_GeneralDiscountNegative_ReturnsInvalidInput(t *testing.T) {
+	groupID := uuid.New()
+	userID := uuid.New()
+	captainMemberID := uuid.New()
+	billID := uuid.New()
+
+	repo := &mockServiceRepo{
+		member: &repository.GroupMember{
+			ID:      captainMemberID,
+			GroupID: groupID,
+			UserID:  userID,
+			Role:    "captain",
+			Status:  "active",
+		},
+		bill: &domain.Bill{
+			ID:               billID,
+			GroupID:          groupID,
+			CreditorMemberID: captainMemberID,
+			Status:           domain.BillStatusDraft,
+			Version:          1,
+		},
+	}
+
+	service := usecase.NewService(repo, &mockOCRProvider{}, &mockStorage{}, &mockProcessor{}, &mockEnqueuer{})
+
+	_, err := service.UpdateDraftBill(context.Background(), userID, billID, groupID, usecase.UpdateDraftRequest{
+		Version:  1,
+		Discount: 10000, // nhỏ hơn tổng discount_amount theo món (20000)
+		Total:    0,
+		Items: []usecase.CreateBillItemRequest{
+			{
+				Name:           "Item 1",
+				LineTotal:      50000,
+				DiscountAmount: 20000,
+				Assignments: []usecase.CreateItemAssignmentRequest{
+					{MemberID: captainMemberID, Weight: "1"},
+				},
+			},
+		},
+	})
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Errorf("expected ErrInvalidInput for general_discount going negative, got %v", err)
 	}
 }

--- a/internal/modules/group/repository/postgres/sqlc/models.go
+++ b/internal/modules/group/repository/postgres/sqlc/models.go
@@ -49,6 +49,8 @@ type Bill struct {
 	MismatchCodes      []string           `json:"mismatch_codes"`
 	ReviewedAt         pgtype.Timestamptz `json:"reviewed_at"`
 	ReviewedByMemberID pgtype.UUID        `json:"reviewed_by_member_id"`
+	TotalItemDiscount  int64              `json:"total_item_discount"`
+	GeneralDiscount    int64              `json:"general_discount"`
 }
 
 type BillIdempotencyKey struct {
@@ -77,16 +79,18 @@ type BillImage struct {
 }
 
 type BillItem struct {
-	ID        pgtype.UUID        `json:"id"`
-	BillID    pgtype.UUID        `json:"bill_id"`
-	GroupID   pgtype.UUID        `json:"group_id"`
-	Name      string             `json:"name"`
-	Quantity  pgtype.Numeric     `json:"quantity"`
-	UnitPrice int64              `json:"unit_price"`
-	LineTotal int64              `json:"line_total"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
-	Position  int16              `json:"position"`
+	ID             pgtype.UUID        `json:"id"`
+	BillID         pgtype.UUID        `json:"bill_id"`
+	GroupID        pgtype.UUID        `json:"group_id"`
+	Name           string             `json:"name"`
+	Quantity       pgtype.Numeric     `json:"quantity"`
+	UnitPrice      int64              `json:"unit_price"`
+	LineTotal      int64              `json:"line_total"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+	Position       int16              `json:"position"`
+	DiscountAmount int64              `json:"discount_amount"`
+	FinalPrice     int64              `json:"final_price"`
 }
 
 type BillItemAssignment struct {
@@ -125,6 +129,7 @@ type Debt struct {
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	SettledAt        pgtype.Timestamptz `json:"settled_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	VoidedAt         pgtype.Timestamptz `json:"voided_at"`
 }
 
 type Group struct {

--- a/internal/modules/notification/repository/postgres/sqlc/models.go
+++ b/internal/modules/notification/repository/postgres/sqlc/models.go
@@ -49,6 +49,8 @@ type Bill struct {
 	MismatchCodes      []string           `json:"mismatch_codes"`
 	ReviewedAt         pgtype.Timestamptz `json:"reviewed_at"`
 	ReviewedByMemberID pgtype.UUID        `json:"reviewed_by_member_id"`
+	TotalItemDiscount  int64              `json:"total_item_discount"`
+	GeneralDiscount    int64              `json:"general_discount"`
 }
 
 type BillIdempotencyKey struct {
@@ -77,16 +79,18 @@ type BillImage struct {
 }
 
 type BillItem struct {
-	ID        pgtype.UUID        `json:"id"`
-	BillID    pgtype.UUID        `json:"bill_id"`
-	GroupID   pgtype.UUID        `json:"group_id"`
-	Name      string             `json:"name"`
-	Quantity  pgtype.Numeric     `json:"quantity"`
-	UnitPrice int64              `json:"unit_price"`
-	LineTotal int64              `json:"line_total"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
-	Position  int16              `json:"position"`
+	ID             pgtype.UUID        `json:"id"`
+	BillID         pgtype.UUID        `json:"bill_id"`
+	GroupID        pgtype.UUID        `json:"group_id"`
+	Name           string             `json:"name"`
+	Quantity       pgtype.Numeric     `json:"quantity"`
+	UnitPrice      int64              `json:"unit_price"`
+	LineTotal      int64              `json:"line_total"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+	Position       int16              `json:"position"`
+	DiscountAmount int64              `json:"discount_amount"`
+	FinalPrice     int64              `json:"final_price"`
 }
 
 type BillItemAssignment struct {
@@ -125,6 +129,7 @@ type Debt struct {
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	SettledAt        pgtype.Timestamptz `json:"settled_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	VoidedAt         pgtype.Timestamptz `json:"voided_at"`
 }
 
 type Group struct {

--- a/internal/platform/ocr/llamaextract/normalizer.go
+++ b/internal/platform/ocr/llamaextract/normalizer.go
@@ -85,9 +85,11 @@ func Normalize(rawBytes []byte) (*domain.OCRCandidate, error) {
 		}
 	}
 
-	// 3. Chuẩn hóa items
+	// 3. Chuẩn hóa items và gộp các dòng khuyến mãi theo món liền trước (Spec 3 AC-15, AC-16)
 	items := make([]domain.OCRCandidateItem, 0, len(raw.Items))
 	var calculatedSubtotal int64
+	var orphanItemDiscount int64    // Dòng khuyến mãi không có món liền trước (Case B)
+	var exceededExcessDiscount int64 // Phần giảm giá vượt quá giá gốc của chính món đó
 	for _, rawItem := range raw.Items {
 		itemMap, ok := rawItem.(map[string]any)
 		if !ok {
@@ -97,6 +99,41 @@ func Normalize(rawBytes []byte) (*domain.OCRCandidate, error) {
 		name := strings.TrimSpace(fmt.Sprint(itemMap["name"]))
 		if name == "" || name == "<nil>" {
 			name = "Món chưa đặt tên"
+		}
+
+		rawLineTotal := parseVNDAmountSigned(itemMap["line_total"])
+		isPromotionLine := isPromotionMarker(name) ||
+			rawLineTotal < 0 ||
+			(isNullOrZeroQuantity(itemMap["quantity"]) && rawLineTotal <= 0)
+
+		if isPromotionLine {
+			promoValue := absInt64(rawLineTotal)
+			if promoValue == 0 {
+				// Dòng khuyến mãi không mang giá trị nào để gộp, bỏ qua an toàn.
+				continue
+			}
+
+			if len(items) == 0 {
+				// Không có món liền trước để gộp vào, coi như giảm giá chung (Spec 3 AC-16).
+				orphanItemDiscount += promoValue
+				warnings = append(warnings, domain.WarningOCROrphanItemDiscount)
+				continue
+			}
+
+			preceding := &items[len(items)-1]
+			preceding.DiscountAmount += promoValue
+			if preceding.DiscountAmount > preceding.LineTotal {
+				// Giảm giá vượt quá giá gốc của chính món đó: chặn về 0, phần dư chuyển sang
+				// giảm giá chung (Spec 3 AC-16).
+				excess := preceding.DiscountAmount - preceding.LineTotal
+				preceding.DiscountAmount = preceding.LineTotal
+				preceding.FinalPrice = 0
+				exceededExcessDiscount += excess
+				warnings = append(warnings, domain.WarningOCRItemDiscountExceeded)
+			} else {
+				preceding.FinalPrice = preceding.LineTotal - preceding.DiscountAmount
+			}
+			continue
 		}
 
 		quantity := NormalizeQuantity(itemMap["quantity"])
@@ -117,10 +154,11 @@ func Normalize(rawBytes []byte) (*domain.OCRCandidate, error) {
 		}
 
 		items = append(items, domain.OCRCandidateItem{
-			Name:      name,
-			Quantity:  quantity,
-			UnitPrice: unitPrice,
-			LineTotal: lineTotal,
+			Name:       name,
+			Quantity:   quantity,
+			UnitPrice:  unitPrice,
+			LineTotal:  lineTotal,
+			FinalPrice: lineTotal, // Không có khuyến mãi riêng: giá cuối bằng giá gốc
 		})
 
 		calculatedSubtotal += lineTotal
@@ -129,12 +167,28 @@ func Normalize(rawBytes []byte) (*domain.OCRCandidate, error) {
 		}
 	}
 
+	// 3b. Tách giảm giá theo món ra khỏi giảm giá chung của hóa đơn (Spec 3 AC-17)
+	var totalItemDiscount int64
+	for _, it := range items {
+		totalItemDiscount += it.DiscountAmount
+	}
+
 	// 4. Chuẩn hóa các trường tiền tệ
 	subtotal := ParseVNDAmount(raw.Subtotal)
 	serviceCharge := ParseVNDAmount(raw.ServiceCharge)
 	vat := ParseVNDAmount(raw.VAT)
-	discount := ParseVNDAmount(raw.Discount)
+	rawDiscount := ParseVNDAmount(raw.Discount) + orphanItemDiscount
 	total := ParseVNDAmount(raw.Total)
+
+	generalDiscount := rawDiscount - totalItemDiscount
+	if generalDiscount < 0 {
+		generalDiscount = 0
+	}
+	// Phần vượt trần của một món (đã bị chặn về LineTotal ở trên) chuyển thẳng vào giảm giá chung,
+	// độc lập với phép trừ total_item_discount ở trên vì total_item_discount đã tính trên giá trị
+	// bị chặn, không phải giá trị gốc trước khi chặn (Spec 3 AC-16).
+	generalDiscount += exceededExcessDiscount
+	totalDiscount := totalItemDiscount + generalDiscount
 
 	// Nếu subtotal không quét được nhưng có items, gán bằng tổng line_total
 	if subtotal == 0 && calculatedSubtotal > 0 {
@@ -143,18 +197,18 @@ func Normalize(rawBytes []byte) (*domain.OCRCandidate, error) {
 
 	// Nếu total không quét được, gán theo công thức
 	if total == 0 && (subtotal > 0 || serviceCharge > 0 || vat > 0) {
-		total = subtotal + serviceCharge + vat - discount
+		total = subtotal + serviceCharge + vat - totalDiscount
 		if total < 0 {
 			total = 0
 		}
 	}
 
-	// 5. Kiểm tra đối soát để sinh Warning (Spec 3 AC-3, AC-5)
+	// 5. Kiểm tra đối soát để sinh Warning (Spec 3 AC-3, AC-5, AC-18)
 	if subtotal > 0 && calculatedSubtotal > 0 && subtotal != calculatedSubtotal {
 		warnings = append(warnings, domain.WarningSubtotalMismatch)
 	}
 
-	expectedTotal := subtotal + serviceCharge + vat - discount
+	expectedTotal := subtotal + serviceCharge + vat - totalDiscount
 	if expectedTotal < 0 {
 		expectedTotal = 0
 	}
@@ -174,39 +228,46 @@ func Normalize(rawBytes []byte) (*domain.OCRCandidate, error) {
 	}
 
 	return &domain.OCRCandidate{
-		MerchantName:  merchantName,
-		BillDate:      billDate,
-		Items:         items,
-		Subtotal:      subtotal,
-		ServiceCharge: serviceCharge,
-		VAT:           vat,
-		Discount:      discount,
-		Total:         total,
-		Confidence:    confidence,
-		Warnings:      warnings,
+		MerchantName:      merchantName,
+		BillDate:          billDate,
+		Items:             items,
+		Subtotal:          subtotal,
+		TotalItemDiscount: totalItemDiscount,
+		GeneralDiscount:   generalDiscount,
+		ServiceCharge:     serviceCharge,
+		VAT:               vat,
+		Discount:          totalDiscount,
+		Total:             total,
+		Confidence:        confidence,
+		Warnings:          warnings,
 	}, nil
 }
 
 // ParseVNDAmount chuẩn hóa các dạng số và chuỗi tiền tệ VND về int64.
 // Hỗ trợ xử lý dấu phân cách hàng nghìn (50.000, 50,000, 50k, 50K, 50 000).
+// Giá trị âm luôn được kẹp về 0 (dùng cho các trường tiền không thể âm).
 func ParseVNDAmount(val any) int64 {
+	n := parseVNDAmountSigned(val)
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+// parseVNDAmountSigned chuẩn hóa tương tự ParseVNDAmount nhưng giữ nguyên dấu âm, dùng để nhận
+// diện các dòng khuyến mãi có line_total âm trong hóa đơn thô (Spec 3 AC-15).
+func parseVNDAmountSigned(val any) int64 {
 	if val == nil {
 		return 0
 	}
 
 	switch v := val.(type) {
 	case int:
-		if v < 0 {
-			return 0
-		}
 		return int64(v)
 	case int64:
-		if v < 0 {
-			return 0
-		}
 		return v
 	case float64:
-		if v < 0 || math.IsNaN(v) || math.IsInf(v, 0) {
+		if math.IsNaN(v) || math.IsInf(v, 0) {
 			return 0
 		}
 		return int64(math.Round(v))
@@ -282,7 +343,7 @@ func ParseVNDAmount(val any) int64 {
 			f *= 1000
 		}
 
-		if f < 0 || math.IsNaN(f) || math.IsInf(f, 0) {
+		if math.IsNaN(f) || math.IsInf(f, 0) {
 			return 0
 		}
 
@@ -290,6 +351,71 @@ func ParseVNDAmount(val any) int64 {
 	default:
 		return 0
 	}
+}
+
+// absInt64 trả về giá trị tuyệt đối của một số nguyên có dấu.
+func absInt64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// isNullOrZeroQuantity báo giá trị quantity thô là null, rỗng, hoặc bằng 0 (Spec 3 AC-15).
+func isNullOrZeroQuantity(val any) bool {
+	if val == nil {
+		return true
+	}
+	switch v := val.(type) {
+	case string:
+		s := strings.TrimSpace(v)
+		if s == "" || s == "<nil>" {
+			return true
+		}
+		if f, err := strconv.ParseFloat(strings.ReplaceAll(s, ",", "."), 64); err == nil {
+			return f == 0
+		}
+		return false
+	case float64:
+		return v == 0
+	case int:
+		return v == 0
+	case int64:
+		return v == 0
+	default:
+		return false
+	}
+}
+
+// vnDiacriticsFolder loại bỏ dấu tiếng Việt để so khớp nhãn khuyến mãi không phân biệt dấu.
+var vnDiacriticsFolder = strings.NewReplacer(
+	"à", "a", "á", "a", "ả", "a", "ã", "a", "ạ", "a",
+	"ă", "a", "ằ", "a", "ắ", "a", "ẳ", "a", "ẵ", "a", "ặ", "a",
+	"â", "a", "ầ", "a", "ấ", "a", "ẩ", "a", "ẫ", "a", "ậ", "a",
+	"è", "e", "é", "e", "ẻ", "e", "ẽ", "e", "ẹ", "e",
+	"ê", "e", "ề", "e", "ế", "e", "ể", "e", "ễ", "e", "ệ", "e",
+	"ì", "i", "í", "i", "ỉ", "i", "ĩ", "i", "ị", "i",
+	"ò", "o", "ó", "o", "ỏ", "o", "õ", "o", "ọ", "o",
+	"ô", "o", "ồ", "o", "ố", "o", "ổ", "o", "ỗ", "o", "ộ", "o",
+	"ơ", "o", "ờ", "o", "ớ", "o", "ở", "o", "ỡ", "o", "ợ", "o",
+	"ù", "u", "ú", "u", "ủ", "u", "ũ", "u", "ụ", "u",
+	"ư", "u", "ừ", "u", "ứ", "u", "ử", "u", "ữ", "u", "ự", "u",
+	"ỳ", "y", "ý", "y", "ỷ", "y", "ỹ", "y", "ỵ", "y",
+	"đ", "d",
+)
+
+// promotionMarkers là các nhãn khuyến mãi thường gặp trên hóa đơn siêu thị và quán ăn (Spec 3 AC-15).
+var promotionMarkers = []string{"km", "khuyen mai", "chiet khau", "giam gia"}
+
+// isPromotionMarker báo tên món có chứa nhãn khuyến mãi, không phân biệt hoa thường và dấu.
+func isPromotionMarker(name string) bool {
+	folded := vnDiacriticsFolder.Replace(strings.ToLower(name))
+	for _, marker := range promotionMarkers {
+		if strings.Contains(folded, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // NormalizeQuantity chuẩn hóa số lượng món thành chuỗi thập phân chuẩn (ví dụ "1", "2.5").

--- a/internal/platform/ocr/llamaextract/normalizer_test.go
+++ b/internal/platform/ocr/llamaextract/normalizer_test.go
@@ -154,3 +154,174 @@ func TestNormalizeWithMismatchesAndAmbiguousDate(t *testing.T) {
 		}
 	}
 }
+
+// TestNormalize_VMRoyalCityBenchmark khớp Spec 3 AC-15, AC-17, AC-18: 5 món với 3 dòng khuyến mãi
+// KM xen kẽ phải gộp đúng vào món liền trước và tổng phải khớp tuyệt đối.
+func TestNormalize_VMRoyalCityBenchmark(t *testing.T) {
+	rawJSON := []byte(`{
+		"merchant_name": "VM Royal City",
+		"items": [
+			{"name": "Lẩu bò", "quantity": "1", "unit_price": 189500, "line_total": 189500},
+			{"name": "KM", "quantity": null, "unit_price": null, "line_total": -64125},
+			{"name": "Rau muống", "quantity": "2", "unit_price": 25000, "line_total": 50000},
+			{"name": "Bia Tiger", "quantity": "6", "unit_price": 20000, "line_total": 120000},
+			{"name": "Khuyến mãi", "quantity": null, "unit_price": null, "line_total": -68175},
+			{"name": "Nước ngọt", "quantity": "4", "unit_price": 15000, "line_total": 60000},
+			{"name": "Tôm hấp", "quantity": "1", "unit_price": 125900, "line_total": 125900},
+			{"name": "KM", "quantity": null, "unit_price": null, "line_total": -59900}
+		],
+		"discount": 0
+	}`)
+
+	candidate, err := Normalize(rawJSON)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+
+	if len(candidate.Items) != 5 {
+		t.Fatalf("expected 5 clean items, got %d: %+v", len(candidate.Items), candidate.Items)
+	}
+	if candidate.Subtotal != 545400 {
+		t.Errorf("expected gross subtotal 545400, got %d", candidate.Subtotal)
+	}
+	if candidate.TotalItemDiscount != 192200 {
+		t.Errorf("expected total_item_discount 192200, got %d", candidate.TotalItemDiscount)
+	}
+	if candidate.GeneralDiscount != 0 {
+		t.Errorf("expected general_discount 0, got %d", candidate.GeneralDiscount)
+	}
+	if candidate.Discount != 192200 {
+		t.Errorf("expected total discount 192200, got %d", candidate.Discount)
+	}
+	if candidate.Total != 545400-192200 {
+		t.Errorf("expected total %d, got %d", 545400-192200, candidate.Total)
+	}
+	for _, w := range candidate.Warnings {
+		if w == domain.WarningTotalMismatch || w == domain.WarningSubtotalMismatch {
+			t.Errorf("did not expect mismatch warning, got %v", candidate.Warnings)
+		}
+	}
+
+	// Lẩu bò hấp thụ khuyến mãi -64.125 liền sau nó.
+	if candidate.Items[0].DiscountAmount != 64125 || candidate.Items[0].FinalPrice != 189500-64125 {
+		t.Errorf("unexpected folded discount on item 0: %+v", candidate.Items[0])
+	}
+	// Bia Tiger hấp thụ khuyến mãi -68.175 liền sau nó.
+	if candidate.Items[2].DiscountAmount != 68175 || candidate.Items[2].FinalPrice != 120000-68175 {
+		t.Errorf("unexpected folded discount on item 2 (Bia Tiger): %+v", candidate.Items[2])
+	}
+	// Tôm hấp hấp thụ khuyến mãi -59.900 liền sau nó.
+	if candidate.Items[4].DiscountAmount != 59900 || candidate.Items[4].FinalPrice != 125900-59900 {
+		t.Errorf("unexpected folded discount on item 4 (Tôm hấp): %+v", candidate.Items[4])
+	}
+}
+
+// TestNormalize_ItemDiscountPlusVoucher khớp Spec 3 AC-17: giảm giá theo món và voucher chung
+// phải được tách riêng, không cộng dồn sai.
+func TestNormalize_ItemDiscountPlusVoucher(t *testing.T) {
+	rawJSON := []byte(`{
+		"items": [
+			{"name": "Bò bít tết", "quantity": "1", "unit_price": 250000, "line_total": 250000},
+			{"name": "KM", "quantity": null, "unit_price": null, "line_total": -50000}
+		],
+		"subtotal": 250000,
+		"discount": 80000,
+		"total": 170000
+	}`)
+
+	candidate, err := Normalize(rawJSON)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+
+	if candidate.TotalItemDiscount != 50000 {
+		t.Errorf("expected total_item_discount 50000, got %d", candidate.TotalItemDiscount)
+	}
+	if candidate.GeneralDiscount != 30000 {
+		t.Errorf("expected general_discount 30000, got %d", candidate.GeneralDiscount)
+	}
+	if candidate.Discount != 80000 {
+		t.Errorf("expected total discount 80000, got %d", candidate.Discount)
+	}
+}
+
+// TestNormalize_OrphanPromotionLine khớp Spec 3 AC-16: dòng khuyến mãi không có món liền trước
+// phải chuyển thành giảm giá chung kèm cảnh báo OCR_ORPHAN_ITEM_DISCOUNT.
+func TestNormalize_OrphanPromotionLine(t *testing.T) {
+	rawJSON := []byte(`{
+		"items": [
+			{"name": "Voucher giảm giá", "quantity": null, "unit_price": null, "line_total": -30000},
+			{"name": "Cà phê sữa", "quantity": "2", "unit_price": 25000, "line_total": 50000}
+		],
+		"subtotal": 50000,
+		"discount": 0,
+		"total": 20000
+	}`)
+
+	candidate, err := Normalize(rawJSON)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+
+	if len(candidate.Items) != 1 {
+		t.Fatalf("expected 1 clean item, got %d: %+v", len(candidate.Items), candidate.Items)
+	}
+	if candidate.Items[0].DiscountAmount != 0 {
+		t.Errorf("expected preserved item to carry no discount, got %+v", candidate.Items[0])
+	}
+	if candidate.TotalItemDiscount != 0 {
+		t.Errorf("expected total_item_discount 0, got %d", candidate.TotalItemDiscount)
+	}
+	if candidate.GeneralDiscount != 30000 {
+		t.Errorf("expected general_discount 30000 from orphan line, got %d", candidate.GeneralDiscount)
+	}
+
+	found := false
+	for _, w := range candidate.Warnings {
+		if w == domain.WarningOCROrphanItemDiscount {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected OCR_ORPHAN_ITEM_DISCOUNT warning, got %v", candidate.Warnings)
+	}
+}
+
+// TestNormalize_ItemDiscountExceedsLinePrice khớp Spec 3 AC-16: giảm giá vượt quá giá gốc của
+// chính món đó phải bị chặn về 0 và phần dư chuyển sang giảm giá chung.
+func TestNormalize_ItemDiscountExceedsLinePrice(t *testing.T) {
+	rawJSON := []byte(`{
+		"items": [
+			{"name": "Trà sữa", "quantity": "1", "unit_price": 100000, "line_total": 100000},
+			{"name": "KM", "quantity": null, "unit_price": null, "line_total": -150000}
+		],
+		"subtotal": 100000,
+		"discount": 0,
+		"total": -50000
+	}`)
+
+	candidate, err := Normalize(rawJSON)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+
+	if len(candidate.Items) != 1 {
+		t.Fatalf("expected 1 clean item, got %d: %+v", len(candidate.Items), candidate.Items)
+	}
+	if candidate.Items[0].DiscountAmount != 100000 || candidate.Items[0].FinalPrice != 0 {
+		t.Errorf("expected discount clamped to line total with final_price 0, got %+v", candidate.Items[0])
+	}
+	if candidate.GeneralDiscount != 50000 {
+		t.Errorf("expected excess 50000 moved to general_discount, got %d", candidate.GeneralDiscount)
+	}
+
+	found := false
+	for _, w := range candidate.Warnings {
+		if w == domain.WarningOCRItemDiscountExceeded {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected OCR_ITEM_DISCOUNT_EXCEEDED warning, got %v", candidate.Warnings)
+	}
+}

--- a/internal/platform/ocr/llamaextract/schema.go
+++ b/internal/platform/ocr/llamaextract/schema.go
@@ -1,174 +1,69 @@
 package llamaextract
 
-import (
-	"encoding/json"
-	"fmt"
-	"strconv"
-	"strings"
-)
-
-// RawReceiptPayload represents the direct unmarshaled structure returned from LlamaExtract OCR.
-type RawReceiptPayload struct {
-	MerchantName  *string          `json:"merchant_name"`
-	BillDate      *string          `json:"bill_date"`
-	Subtotal      *float64         `json:"subtotal"`
-	ServiceCharge *float64         `json:"service_charge"`
-	VAT           *float64         `json:"vat"`
-	Discount      *float64         `json:"discount"`
-	Total         *float64         `json:"total"`
-	Items         []RawItemPayload `json:"items"`
-}
-
-// RawItemPayload represents a raw item line extracted by the OCR model.
-type RawItemPayload struct {
-	Name      string        `json:"name"`
-	Quantity  *FlexQuantity `json:"quantity"`
-	UnitPrice *float64      `json:"unit_price"`
-	LineTotal *float64      `json:"line_total"`
-}
-
-// FlexQuantity allows parsing quantity whether it arrives as a string ("1", "0,950", "2.5"), float (1.5), int (2), or null.
-type FlexQuantity struct {
-	Value float64
-	Valid bool
-}
-
-// UnmarshalJSON customizes deserialization for flexible quantity formats.
-func (fq *FlexQuantity) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || len(data) == 0 {
-		fq.Value = 0
-		fq.Valid = false
-		return nil
+// ReceiptSchema trả về cấu trúc JSON Schema định nghĩa dữ liệu cần trích xuất từ hóa đơn
+// gửi cho LlamaExtract API v2 (Spec 3 AC-3). Các dòng khuyến mãi/chiết khấu theo món (ví dụ "KM",
+// "Khuyến mãi") vẫn được model trả về như một item bình thường với line_total âm hoặc bằng 0; việc
+// gộp chúng vào món liền trước là trách nhiệm của Normalize ở normalizer.go (Spec 3 AC-15..AC-18),
+// không phải của schema gửi cho provider.
+func ReceiptSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"merchant_name": map[string]any{
+				"type":        "string",
+				"description": "Tên nhà hàng, quán ăn, cửa hàng hoặc đơn vị xuất hóa đơn (nếu có)",
+			},
+			"bill_date": map[string]any{
+				"type":        "string",
+				"description": "Ngày lập hóa đơn theo định dạng YYYY-MM-DD hoặc DD/MM/YYYY",
+			},
+			"items": map[string]any{
+				"type":        "array",
+				"description": "Danh sách các món ăn, đồ uống hoặc dịch vụ trên hóa đơn, bao gồm cả các dòng khuyến mãi/chiết khấu riêng theo món (như 'KM', 'Khuyến mãi') nếu có, với line_total âm hoặc bằng giá trị được giảm",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{
+							"type":        "string",
+							"description": "Tên món, sản phẩm, hoặc nhãn khuyến mãi (ví dụ 'KM', 'Khuyến mãi', 'Chiết khấu', 'Giảm giá')",
+						},
+						"quantity": map[string]any{
+							"type":        "string",
+							"description": "Số lượng món (ví dụ: '1', '2', '0.5'); để trống hoặc 0 với dòng khuyến mãi không có số lượng",
+						},
+						"unit_price": map[string]any{
+							"type":        "integer",
+							"description": "Đơn giá bằng số nguyên VND",
+						},
+						"line_total": map[string]any{
+							"type":        "integer",
+							"description": "Thành tiền bằng số nguyên VND; là số âm nếu đây là dòng khuyến mãi/chiết khấu áp dụng cho món liền trước",
+						},
+					},
+					"required": []string{"name", "line_total"},
+				},
+			},
+			"subtotal": map[string]any{
+				"type":        "integer",
+				"description": "Tổng tiền hàng trước thuế phí hoặc giảm giá (VND)",
+			},
+			"service_charge": map[string]any{
+				"type":        "integer",
+				"description": "Phí dịch vụ nếu có ghi trên hóa đơn (VND), mặc định 0",
+			},
+			"vat": map[string]any{
+				"type":        "integer",
+				"description": "Tiền thuế GTGT / VAT nếu có ghi trên hóa đơn (VND), mặc định 0",
+			},
+			"discount": map[string]any{
+				"type":        "integer",
+				"description": "Tiền giảm giá, voucher, chiết khấu chung của hóa đơn nếu có ghi riêng biệt (VND), mặc định 0. Không cộng dồn các khuyến mãi đã nằm trong từng dòng item.",
+			},
+			"total": map[string]any{
+				"type":        "integer",
+				"description": "Tổng số tiền thanh toán cuối cùng ghi trên hóa đơn (VND)",
+			},
+		},
+		"required": []string{"items", "total"},
 	}
-
-	// 1. Try unmarshaling as float/int
-	var num float64
-	if err := json.Unmarshal(data, &num); err == nil {
-		fq.Value = num
-		fq.Valid = true
-		return nil
-	}
-
-	// 2. Try unmarshaling as string
-	var str string
-	if err := json.Unmarshal(data, &str); err == nil {
-		str = strings.TrimSpace(str)
-		if str == "" || str == "null" {
-			fq.Value = 0
-			fq.Valid = false
-			return nil
-		}
-
-		// Replace Vietnamese comma decimal with dot: "0,950" -> "0.950"
-		normalized := strings.ReplaceAll(str, ",", ".")
-		// Strip non-numeric suffix if present, e.g. "0.950 kg" -> "0.950"
-		fields := strings.Fields(normalized)
-		if len(fields) > 0 {
-			normalized = fields[0]
-		}
-
-		parsed, err := strconv.ParseFloat(normalized, 64)
-		if err != nil {
-			return fmt.Errorf("invalid quantity string %q: %w", str, err)
-		}
-		fq.Value = parsed
-		fq.Valid = true
-		return nil
-	}
-
-	return fmt.Errorf("cannot unmarshal %s into FlexQuantity", string(data))
 }
-
-// ReceiptCandidate represents the normalized, validated candidate result ready to be stored in ocr_jobs.candidate.
-type ReceiptCandidate struct {
-	MerchantName      *string         `json:"merchant_name"`
-	BillDate          *string         `json:"bill_date"` // ISO YYYY-MM-DD or DD/MM/YYYY
-	Subtotal          int64           `json:"subtotal"`  // Gross items sum (VND)
-	TotalItemDiscount int64           `json:"total_item_discount"` // Sum of item-specific discounts (VND)
-	GeneralDiscount   int64           `json:"general_discount"`   // Bill-wide voucher discount (VND)
-	TotalDiscount     int64           `json:"total_discount"`     // TotalItemDiscount + GeneralDiscount (VND)
-	ServiceCharge     int64           `json:"service_charge"`     // Service fee (VND)
-	VAT               int64           `json:"vat"`                // VAT (VND)
-	ReportedTotal     int64           `json:"reported_total"`     // Total from OCR bill (VND)
-	ComputedTotal     int64           `json:"computed_total"`     // Subtotal - TotalDiscount + ServiceCharge + VAT (VND)
-	MismatchWarning   bool            `json:"mismatch_warning"`
-	MismatchDelta     int64           `json:"mismatch_delta"` // ComputedTotal - ReportedTotal
-	Warnings          []string        `json:"warnings,omitempty"`
-	Items             []ItemCandidate `json:"items"`
-}
-
-// ItemCandidate represents a normalized line item ready for candidate review and bill creation.
-type ItemCandidate struct {
-	Position       int16   `json:"position"`
-	Name           string  `json:"name"`
-	Quantity       float64 `json:"quantity"`
-	UnitPrice      int64   `json:"unit_price"`      // Unit price before discount (VND)
-	LineTotal      int64   `json:"line_total"`      // Gross total = Quantity × UnitPrice (VND)
-	DiscountAmount int64   `json:"discount_amount"` // Item-specific discount (VND)
-	FinalPrice     int64   `json:"final_price"`     // Net price = LineTotal - DiscountAmount (VND)
-}
-// Schema cũ khi chưa có 0004. Item Discount OCR Parsing and Mapping
-// // ReceiptSchema trả về cấu trúc JSON Schema định nghĩa dữ liệu cần trích xuất từ hóa đơn
-// // gửi cho LlamaExtract API v2 (Spec 3 AC-3).
-// func ReceiptSchema() map[string]any {
-// 	return map[string]any{
-// 		"type": "object",
-// 		"properties": map[string]any{
-// 			"merchant_name": map[string]any{
-// 				"type":        "string",
-// 				"description": "Tên nhà hàng, quán ăn, cửa hàng hoặc đơn vị xuất hóa đơn (nếu có)",
-// 			},
-// 			"bill_date": map[string]any{
-// 				"type":        "string",
-// 				"description": "Ngày lập hóa đơn theo định dạng YYYY-MM-DD hoặc DD/MM/YYYY",
-// 			},
-// 			"items": map[string]any{
-// 				"type":        "array",
-// 				"description": "Danh sách các món ăn, đồ uống hoặc dịch vụ trên hóa đơn",
-// 				"items": map[string]any{
-// 					"type": "object",
-// 					"properties": map[string]any{
-// 						"name": map[string]any{
-// 							"type":        "string",
-// 							"description": "Tên món hoặc sản phẩm",
-// 						},
-// 						"quantity": map[string]any{
-// 							"type":        "string",
-// 							"description": "Số lượng món (ví dụ: '1', '2', '0.5')",
-// 						},
-// 						"unit_price": map[string]any{
-// 							"type":        "integer",
-// 							"description": "Đơn giá bằng số nguyên VND",
-// 						},
-// 						"line_total": map[string]any{
-// 							"type":        "integer",
-// 							"description": "Thành tiền bằng số nguyên VND",
-// 						},
-// 					},
-// 					"required": []string{"name", "line_total"},
-// 				},
-// 			},
-// 			"subtotal": map[string]any{
-// 				"type":        "integer",
-// 				"description": "Tổng tiền hàng trước thuế phí hoặc giảm giá (VND)",
-// 			},
-// 			"service_charge": map[string]any{
-// 				"type":        "integer",
-// 				"description": "Phí dịch vụ nếu có ghi trên hóa đơn (VND), mặc định 0",
-// 			},
-// 			"vat": map[string]any{
-// 				"type":        "integer",
-// 				"description": "Tiền thuế GTGT / VAT nếu có ghi trên hóa đơn (VND), mặc định 0",
-// 			},
-// 			"discount": map[string]any{
-// 				"type":        "integer",
-// 				"description": "Tiền giảm giá, voucher, chiết khấu nếu có (VND), mặc định 0",
-// 			},
-// 			"total": map[string]any{
-// 				"type":        "integer",
-// 				"description": "Tổng số tiền thanh toán cuối cùng ghi trên hóa đơn (VND)",
-// 			},
-// 		},
-// 		"required": []string{"items", "total"},
-// 	}
-// }

--- a/internal/platform/ocr/llamaextract/schema_test.go
+++ b/internal/platform/ocr/llamaextract/schema_test.go
@@ -1,0 +1,80 @@
+package llamaextract
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestReceiptSchema_MarshalsToValidJSON đảm bảo schema gửi cho LlamaExtract API (client.go dùng
+// trực tiếp trong createExtractionJob) luôn là JSON hợp lệ. Một map chứa giá trị không thể
+// marshal (ví dụ channel, func) sẽ làm request tới provider lỗi âm thầm ở tầng http, nên đây là
+// bất biến cần khóa lại bằng test, không chỉ nhìn bằng mắt.
+func TestReceiptSchema_MarshalsToValidJSON(t *testing.T) {
+	raw, err := json.Marshal(ReceiptSchema())
+	if err != nil {
+		t.Fatalf("ReceiptSchema() phải marshal được sang JSON, lỗi: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("JSON của ReceiptSchema() phải unmarshal lại được, lỗi: %v", err)
+	}
+}
+
+// TestReceiptSchema_RequiresItemsAndTotal khớp Spec 3 AC-3: normalizer.go (Normalize) giả định
+// payload luôn có items và total để tính toán, nên schema gửi cho provider phải bắt buộc đúng
+// hai trường này, nếu không provider có thể trả về thiếu và làm sập bước chuẩn hóa phía sau.
+func TestReceiptSchema_RequiresItemsAndTotal(t *testing.T) {
+	schema := ReceiptSchema()
+
+	required, ok := schema["required"].([]string)
+	if !ok {
+		t.Fatalf("mong đợi schema['required'] là []string, nhận %T", schema["required"])
+	}
+
+	requiredSet := make(map[string]bool, len(required))
+	for _, r := range required {
+		requiredSet[r] = true
+	}
+
+	for _, want := range []string{"items", "total"} {
+		if !requiredSet[want] {
+			t.Errorf("mong đợi '%s' nằm trong required của schema gốc, nhận %v", want, required)
+		}
+	}
+}
+
+// TestReceiptSchema_ItemRequiresNameAndLineTotal khớp Spec 3 AC-15: normalizer.go phân loại dòng
+// khuyến mãi dựa trên name và line_total của từng item (isPromotionMarker, rawLineTotal), nên cả
+// hai trường này phải luôn được provider trả về.
+func TestReceiptSchema_ItemRequiresNameAndLineTotal(t *testing.T) {
+	schema := ReceiptSchema()
+
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("mong đợi schema['properties'] là map[string]any, nhận %T", schema["properties"])
+	}
+	itemsField, ok := properties["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("mong đợi properties['items'] là map[string]any, nhận %T", properties["items"])
+	}
+	itemSchema, ok := itemsField["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("mong đợi items['items'] là map[string]any, nhận %T", itemsField["items"])
+	}
+	itemRequired, ok := itemSchema["required"].([]string)
+	if !ok {
+		t.Fatalf("mong đợi item['required'] là []string, nhận %T", itemSchema["required"])
+	}
+
+	requiredSet := make(map[string]bool, len(itemRequired))
+	for _, r := range itemRequired {
+		requiredSet[r] = true
+	}
+
+	for _, want := range []string{"name", "line_total"} {
+		if !requiredSet[want] {
+			t.Errorf("mong đợi '%s' nằm trong required của item, nhận %v", want, itemRequired)
+		}
+	}
+}


### PR DESCRIPTION
## What

Fixes item level bill discounts (Spec 0004) so they actually persist: the repository and
usecase layers never wired `discount_amount`/`final_price`/`total_item_discount`/
`general_discount` through to the database, breaking every bill creation once the new
columns' CHECK constraints were live. Also adds `discount_amount` to `POST /bills` and
`PUT /bills/{id}` (Spec 0005) so a manual edit after OCR no longer wipes out item level
promotions and turns them into a general discount.

## Why

Implements docs/specs/0003-bill-ocr-v1/0004-item-discount-ocr-parsing.md and
docs/specs/0003-bill-ocr-v1/0005-manual-edit-item-discount.md. Found via `/check verify`:
the OCR normalizer folding logic (AC-15 to AC-18) was built but never actually reached the
database or the allocator, and the one normal next step after OCR (reassigning items to the
right people) silently discarded the discount data entirely.

## Changes

- `internal/platform/ocr/llamaextract/normalizer.go`: split the "orphan discount" and
  "discount exceeds line total" accumulators so the exceeded amount flows straight into
  `general_discount` instead of being netted against `total_item_discount` and disappearing.
- `internal/platform/ocr/llamaextract/schema.go`: restored `ReceiptSchema()` (was commented
  out, breaking the build) and documented that promo lines can carry a negative `line_total`.
- `internal/modules/bill/repository/postgres/repository.go`: `CreateBill`, `CreateBillItem`,
  `UpdateDraftBill`, and both `toDomain*` mappers now read and write the discount fields;
  previously they silently defaulted to zero and violated the database's own CHECK
  constraints on any bill with a nonzero `line_total` or `discount`.
- `internal/modules/bill/usecase/service.go`: `ApplyCandidate` now copies the OCR
  candidate's discount fields onto the domain objects; `CreateBill` and `UpdateDraftBill`
  validate `discount_amount` per item (against the derived `line_total`, not the raw
  request value), derive `final_price`/`total_item_discount`/`general_discount` server
  side, and reject negative values; `toAllocationInput` now feeds the allocator each
  item's net `final_price` and only the bill's `general_discount`, so an item's own
  promotion stays with whoever is assigned that item instead of being spread across the
  group.
- `db/migrations/000006_bill_and_ocr_v1.sql`: fixed a pre existing bug that made the
  migration unrunnable on a fresh database (it used a newly added enum value in the same
  implicit transaction it was created in); also added the `debts.voided_at` column and
  `debt_status` enum value that `VoidBill` already needed but no migration had added.
- `db/migrations/000007_bill_item_discount_v1.sql` (new): adds `discount_amount`/
  `final_price` to `bill_items` and `total_item_discount`/`general_discount` to `bills`,
  with CHECK constraints enforcing the composition.
- `docs/openapi.yaml`: documents `discount_amount` on both item request bodies, and
  `final_price`/`total_item_discount`/`general_discount` on the response schemas.
- Incidental: other modules' `internal/**/repository/postgres/sqlc/*.go` files picked up
  formatting only changes from re running `sqlc generate` for the whole project; no
  behavior change in those files.

## How to test / verify

- `go test ./...` (all green except one pre existing, unrelated failure:
  `TestIntegration_LlamaExtract` needs a local test image that wasn't present before this
  branch added `testdata/bills/anh2.png` and `image.png`; with those present it now passes
  live against the real LlamaExtract provider too).
- Live checked against a real Postgres 18 instance and running server (not just unit
  tests): `POST /bills` with `discount > 0` and no item discount (previously `500` on
  `check_bills_discount_composition`) now returns `201`; `PUT /bills/{id}` with a per item
  `discount_amount` round trips correctly and the allocation breakdown isolates the
  discount to the assigned member; `discount_amount` exceeding an item's derived
  `line_total` returns `400 VALIDATION_FAILED`.
- See `docs/specs/0003-bill-ocr-v1/verify.md` for the full evidence log, including a live
  run against a real receipt with the exact interleaved `KM` discount pattern this feature
  targets.

## Risk & rollout

No feature flag; the new request fields are additive and default to `0`, matching
today's behavior for any client that doesn't send them. One rollout risk: once the mobile
app starts sending per item `discount_amount`, it must keep sending `discount` as the
combined (item plus general) total, exactly as before, or `general_discount` can go
negative and a previously working edit will now get `400 VALIDATION_FAILED` instead of
silently misfiling the discount. Migration `000007` is new; migration `000006`'s fix
changes how it runs (`NO TRANSACTION`) but not what it does to an already migrated database.

## Notes for reviewers

The repository and usecase wiring bug (discount fields never reaching the database) meant
the item discount feature was completely broken from the moment its migration would have
been applied, despite the OCR normalizer and its tests being correct in isolation. Worth
double checking the validation order in `CreateBill`/`UpdateDraftBill`
(`internal/modules/bill/usecase/service.go`): item discount checks run against the
**derived** `line_total` (after the `unit_price × quantity` fallback), before assignment
weight validation, per spec 0005.
