### PR TITLE
feat(group): thêm dữ liệu hiển thị cho danh sách nhóm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ bin/
 # Test receipt images (contain personal/sensitive spending data)
 testdata/bills/*
 !testdata/bills/.gitkeep
+
+# Database dumps (chứa email thật, hash mật khẩu bcrypt và token phiên)
+backups/
+*.dump

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2076,12 +2076,36 @@ components:
         net_balance: {type: string, description: Decimal VND string; positive means the member is owed}
     GroupListItem:
       type: object
-      required: [group, caller_membership_id, caller_role, active_member_count]
+      description: >-
+        One group card. Every display field is built in a single query so the
+        group list never needs a follow-up GET /groups/{id} per group.
+      required: [group, caller_membership_id, caller_role, active_member_count,
+                 caller_net_balance, pending_bill_count, last_activity]
       properties:
         group: {$ref: "#/components/schemas/Group"}
         caller_membership_id: {type: string, format: uuid}
         caller_role: {type: string, enum: [captain, member]}
         active_member_count: {type: integer}
+        caller_net_balance:
+          type: string
+          pattern: '^-?[0-9]+$'
+          description: >-
+            The caller's net VND balance in this group, sent as a string so large
+            values survive JSON parsing. Positive means owed to the caller,
+            negative means the caller owes, 0 when the group has no open debts.
+        pending_bill_count:
+          type: integer
+          description: Bills that are neither finalized nor voided, the same definition the disband guard uses
+        last_activity:
+          nullable: true
+          description: The group's most recent activity; null when the group has none
+          allOf: [{$ref: "#/components/schemas/ActivitySummary"}]
+    ActivitySummary:
+      type: object
+      required: [description, created_at]
+      properties:
+        description: {type: string, description: Vietnamese description already rendered by the backend}
+        created_at: {type: string, format: date-time}
     CreateGroupResponse:
       type: object
       required: [group, membership]

--- a/internal/modules/group/delivery/http/response.go
+++ b/internal/modules/group/delivery/http/response.go
@@ -47,6 +47,17 @@ type groupListItemResponse struct {
 	CallerMembershipID string        `json:"caller_membership_id"`
 	CallerRole         string        `json:"caller_role"`
 	ActiveMemberCount  int           `json:"active_member_count"`
+	// CallerNetBalance là số dư ròng VND của caller, trả dạng chuỗi giống
+	// balanceResponse để client không mất chính xác khi parse số lớn.
+	CallerNetBalance string `json:"caller_net_balance"`
+	PendingBillCount int    `json:"pending_bill_count"`
+	// LastActivity null khi nhóm chưa có hoạt động nào.
+	LastActivity *activitySummaryResponse `json:"last_activity"`
+}
+
+type activitySummaryResponse struct {
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 func newGroupResponse(g domain.Group) groupResponse {
@@ -76,12 +87,21 @@ func newBalanceResponse(b domain.Balance) balanceResponse {
 }
 
 func newGroupListItemResponse(item domain.GroupListItem) groupListItemResponse {
-	return groupListItemResponse{
+	resp := groupListItemResponse{
 		Group:              newGroupResponse(item.Group),
 		CallerMembershipID: item.CallerMembershipID,
 		CallerRole:         item.CallerRole,
 		ActiveMemberCount:  item.ActiveMemberCount,
+		CallerNetBalance:   strconv.FormatInt(item.CallerNetBalance, 10),
+		PendingBillCount:   item.PendingBillCount,
 	}
+	if item.LastActivity != nil {
+		resp.LastActivity = &activitySummaryResponse{
+			Description: item.LastActivity.Description,
+			CreatedAt:   item.LastActivity.CreatedAt,
+		}
+	}
+	return resp
 }
 
 type inviteResponse struct {

--- a/internal/modules/group/domain/group.go
+++ b/internal/modules/group/domain/group.go
@@ -27,6 +27,9 @@ type Group struct {
 	// BillSubmissionLockedAt là mốc thời gian khóa gửi hóa đơn một chiều của V1
 	// (Spec 0008 AC-1). NULL nghĩa là nhóm còn mở, khác NULL là đã khóa vĩnh viễn.
 	BillSubmissionLockedAt *time.Time
+	// Emoji là icon hiển thị của nhóm. NULL khi nhóm chưa chọn icon; client tự
+	// quyết định icon mặc định thay vì backend áp đặt một giá trị.
+	Emoji *string
 }
 
 type Membership struct {
@@ -40,11 +43,28 @@ type Membership struct {
 }
 
 // GroupListItem is one row of the caller's active group membership list.
+// Mọi trường ở đây được dựng trong một truy vấn duy nhất để màn hình danh sách
+// nhóm không phải gọi thêm GET /groups/{id} cho từng nhóm.
 type GroupListItem struct {
 	Group              Group
 	CallerMembershipID string
 	CallerRole         string
 	ActiveMemberCount  int
+	// CallerNetBalance là số dư ròng VND của caller trong nhóm: dương nghĩa là
+	// được nhận về, âm nghĩa là còn nợ, 0 khi nhóm chưa phát sinh công nợ.
+	CallerNetBalance int64
+	// PendingBillCount đếm hóa đơn chưa chốt (khác finalized và voided), cùng
+	// định nghĩa với rào chắn giải tán nhóm.
+	PendingBillCount int
+	// LastActivity là hoạt động gần nhất của nhóm, nil khi nhóm chưa có hoạt động.
+	LastActivity *ActivitySummary
+}
+
+// ActivitySummary là bản rút gọn của một dòng hoạt động, đủ để hiển thị trên
+// thẻ nhóm mà không phải tải cả trang hoạt động.
+type ActivitySummary struct {
+	Description string
+	CreatedAt   time.Time
 }
 
 // Member is an active group member as shown on the group detail screen.

--- a/internal/modules/group/repository/postgres/queries/groups.sql
+++ b/internal/modules/group/repository/postgres/queries/groups.sql
@@ -12,10 +12,25 @@ RETURNING *;
 SELECT display_name FROM users WHERE id = $1;
 
 -- name: ListActiveGroupsForUser :many
+-- Mỗi hàng mang đủ dữ liệu cho một thẻ nhóm ở FE nên danh sách không cần
+-- gọi thêm GET /groups/{id} cho từng nhóm (báo cáo đối chiếu mục 3.2, 3.3).
 SELECT g.id, g.name, g.currency, g.created_by, g.created_at,
        g.bill_submission_locked_at,
        m.id AS membership_id, m.role,
-       (SELECT count(*) FROM group_members am WHERE am.group_id = g.id AND am.status = 'active') AS active_member_count
+       (SELECT count(*) FROM group_members am WHERE am.group_id = g.id AND am.status = 'active') AS active_member_count,
+       -- Số dư ròng của chính caller trong nhóm; v_member_balances chỉ có hàng
+       -- khi thành viên có công nợ nên COALESCE về 0 cho nhóm chưa phát sinh.
+       COALESCE((SELECT b.net_balance FROM v_member_balances b WHERE b.member_id = m.id), 0)::bigint AS caller_net_balance,
+       -- Hóa đơn chưa chốt, dùng chung định nghĩa với CountUnfinishedBills.
+       (SELECT count(*) FROM bills bi WHERE bi.group_id = g.id AND bi.status NOT IN ('finalized', 'voided')) AS pending_bill_count,
+       -- Hoạt động gần nhất, NULL khi nhóm chưa có hoạt động nào. Gói thành
+       -- jsonb thay vì hai cột phẳng vì sqlc suy cột phẳng lấy từ subquery
+       -- thành NOT NULL (description là NOT NULL trong bảng) và sẽ vỡ khi
+       -- scan NULL. Truy vấn dùng idx_group_activities_timeline.
+       (SELECT jsonb_build_object('description', a.description, 'created_at', a.created_at)
+        FROM group_activities a
+        WHERE a.group_id = g.id
+        ORDER BY a.created_at DESC, a.id DESC LIMIT 1) AS last_activity
 FROM group_members m
 JOIN groups g ON g.id = m.group_id
 WHERE m.user_id = $1

--- a/internal/modules/group/repository/postgres/repository.go
+++ b/internal/modules/group/repository/postgres/repository.go
@@ -130,6 +130,10 @@ func (r *postgresRepository) ListGroups(ctx context.Context, p repository.ListGr
 			v := row.BillSubmissionLockedAt.Time
 			submissionLockedAt = &v
 		}
+		lastActivity, decodeErr := decodeActivitySummary(row.LastActivity)
+		if decodeErr != nil {
+			return nil, nil, decodeErr
+		}
 		items = append(items, domain.GroupListItem{
 			Group: domain.Group{
 				ID:                     uuid.UUID(row.ID.Bytes).String(),
@@ -143,6 +147,9 @@ func (r *postgresRepository) ListGroups(ctx context.Context, p repository.ListGr
 			CallerMembershipID: uuid.UUID(row.MembershipID.Bytes).String(),
 			CallerRole:         fmt.Sprint(row.Role),
 			ActiveMemberCount:  int(row.ActiveMemberCount),
+			CallerNetBalance:   row.CallerNetBalance,
+			PendingBillCount:   int(row.PendingBillCount),
+			LastActivity:       lastActivity,
 		})
 	}
 
@@ -1175,6 +1182,22 @@ func mapMembership(m dbgen.GroupMember) *domain.Membership {
 }
 
 func pgUUID(v uuid.UUID) pgtype.UUID { return pgtype.UUID{Bytes: v, Valid: true} }
+
+// decodeActivitySummary đọc cột jsonb last_activity của ListActiveGroupsForUser.
+// Cột là NULL (raw rỗng) khi nhóm chưa có hoạt động nào.
+func decodeActivitySummary(raw []byte) (*domain.ActivitySummary, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var decoded struct {
+		Description string    `json:"description"`
+		CreatedAt   time.Time `json:"created_at"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, fmt.Errorf("decode last_activity: %w", err)
+	}
+	return &domain.ActivitySummary{Description: decoded.Description, CreatedAt: decoded.CreatedAt}, nil
+}
 
 func mapWriteError(err error) error {
 	var pgErr *pgconn.PgError

--- a/internal/modules/group/repository/postgres/repository_integration_test.go
+++ b/internal/modules/group/repository/postgres/repository_integration_test.go
@@ -1242,3 +1242,83 @@ func TestListActivities_RejectsAnUndecodableCursor(t *testing.T) {
 		t.Fatalf("error = %v, want ErrInvalidCursor", err)
 	}
 }
+
+// --- Group list display fields (báo cáo đối chiếu Nhóm mục 3.1 - 3.3) -----
+
+// ListGroups phải dựng đủ dữ liệu một thẻ nhóm trong đúng một truy vấn: emoji,
+// số dư ròng của caller, số hóa đơn chưa chốt và hoạt động gần nhất.
+func TestListGroups_ReturnsDisplayFieldsForTheGroupCard(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+	cleanup := newCleanup(t, pool)
+	repo := New(pool)
+
+	captainID := createUser(t, ctx, pool, cleanup, "Captain")
+	group, captainMembership := mustCreateGroup(t, ctx, repo, cleanup, "Đà Lạt", captainID)
+
+	// Một hóa đơn draft (chưa chốt) và một hóa đơn đã chốt: chỉ hóa đơn draft
+	// được đếm vào pending_bill_count.
+	var draftBillID string
+	if err := pool.QueryRow(ctx, `INSERT INTO bills (group_id, creditor_member_id, status, total) VALUES ($1,$2,'draft',90000) RETURNING id`,
+		group.ID, captainMembership.ID).Scan(&draftBillID); err != nil {
+		t.Fatalf("insert draft bill: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO bills (group_id, creditor_member_id, status, total, finalized_at) VALUES ($1,$2,'finalized',10000,now())`,
+		group.ID, captainMembership.ID); err != nil {
+		t.Fatalf("insert finalized bill: %v", err)
+	}
+
+	// Caller là chủ nợ 30000 nên số dư ròng của caller phải là +30000.
+	debtorUserID := createUser(t, ctx, pool, cleanup, "Debtor")
+	var debtorMembershipID string
+	if err := pool.QueryRow(ctx, `INSERT INTO group_members (group_id, user_id, role, status) VALUES ($1,$2,'member','active') RETURNING id`,
+		group.ID, debtorUserID).Scan(&debtorMembershipID); err != nil {
+		t.Fatalf("insert debtor membership: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO debts (group_id, bill_id, debtor_member_id, creditor_member_id, amount, status) VALUES ($1,$2,$3,$4,30000,'awaiting')`,
+		group.ID, draftBillID, debtorMembershipID, captainMembership.ID); err != nil {
+		t.Fatalf("insert debt: %v", err)
+	}
+
+	items, _, err := repo.ListGroups(ctx, repository.ListGroupsParams{UserID: captainID, Limit: 10})
+	if err != nil {
+		t.Fatalf("list groups: %v", err)
+	}
+	var item *domain.GroupListItem
+	for i := range items {
+		if items[i].Group.ID == group.ID {
+			item = &items[i]
+			break
+		}
+	}
+	if item == nil {
+		t.Fatalf("group %s missing from the caller's list", group.ID)
+	}
+	if item.CallerNetBalance != 30000 {
+		t.Errorf("CallerNetBalance = %d, want 30000 (caller is the creditor)", item.CallerNetBalance)
+	}
+	if item.PendingBillCount != 1 {
+		t.Errorf("PendingBillCount = %d, want 1 (finalized bills excluded)", item.PendingBillCount)
+	}
+	if item.LastActivity == nil {
+		t.Fatal("LastActivity = nil, want the group_created activity")
+	}
+	if item.LastActivity.Description == "" || item.LastActivity.CreatedAt.IsZero() {
+		t.Errorf("LastActivity = %+v, want a populated description and timestamp", *item.LastActivity)
+	}
+
+	// Nhóm mới của một người khác chưa có công nợ hay hóa đơn: các trường hiển
+	// thị phải về 0 thay vì lỗi scan.
+	loneUserID := createUser(t, ctx, pool, cleanup, "Lone")
+	lone, _ := mustCreateGroup(t, ctx, repo, cleanup, "Nhóm trống", loneUserID)
+	loneItems, _, err := repo.ListGroups(ctx, repository.ListGroupsParams{UserID: loneUserID, Limit: 10})
+	if err != nil {
+		t.Fatalf("list lone groups: %v", err)
+	}
+	if len(loneItems) != 1 || loneItems[0].Group.ID != lone.ID {
+		t.Fatalf("lone list = %+v, want exactly the new group", loneItems)
+	}
+	if loneItems[0].CallerNetBalance != 0 || loneItems[0].PendingBillCount != 0 {
+		t.Errorf("empty group counters = (%d, %d), want (0, 0)", loneItems[0].CallerNetBalance, loneItems[0].PendingBillCount)
+	}
+}

--- a/internal/modules/group/repository/postgres/sqlc/groups.sql.go
+++ b/internal/modules/group/repository/postgres/sqlc/groups.sql.go
@@ -417,7 +417,20 @@ const listActiveGroupsForUser = `-- name: ListActiveGroupsForUser :many
 SELECT g.id, g.name, g.currency, g.created_by, g.created_at,
        g.bill_submission_locked_at,
        m.id AS membership_id, m.role,
-       (SELECT count(*) FROM group_members am WHERE am.group_id = g.id AND am.status = 'active') AS active_member_count
+       (SELECT count(*) FROM group_members am WHERE am.group_id = g.id AND am.status = 'active') AS active_member_count,
+       -- Số dư ròng của chính caller trong nhóm; v_member_balances chỉ có hàng
+       -- khi thành viên có công nợ nên COALESCE về 0 cho nhóm chưa phát sinh.
+       COALESCE((SELECT b.net_balance FROM v_member_balances b WHERE b.member_id = m.id), 0)::bigint AS caller_net_balance,
+       -- Hóa đơn chưa chốt, dùng chung định nghĩa với CountUnfinishedBills.
+       (SELECT count(*) FROM bills bi WHERE bi.group_id = g.id AND bi.status NOT IN ('finalized', 'voided')) AS pending_bill_count,
+       -- Hoạt động gần nhất, NULL khi nhóm chưa có hoạt động nào. Gói thành
+       -- jsonb thay vì hai cột phẳng vì sqlc suy cột phẳng lấy từ subquery
+       -- thành NOT NULL (description là NOT NULL trong bảng) và sẽ vỡ khi
+       -- scan NULL. Truy vấn dùng idx_group_activities_timeline.
+       (SELECT jsonb_build_object('description', a.description, 'created_at', a.created_at)
+        FROM group_activities a
+        WHERE a.group_id = g.id
+        ORDER BY a.created_at DESC, a.id DESC LIMIT 1) AS last_activity
 FROM group_members m
 JOIN groups g ON g.id = m.group_id
 WHERE m.user_id = $1
@@ -446,8 +459,13 @@ type ListActiveGroupsForUserRow struct {
 	MembershipID           pgtype.UUID        `json:"membership_id"`
 	Role                   interface{}        `json:"role"`
 	ActiveMemberCount      int64              `json:"active_member_count"`
+	CallerNetBalance       int64              `json:"caller_net_balance"`
+	PendingBillCount       int64              `json:"pending_bill_count"`
+	LastActivity           []byte             `json:"last_activity"`
 }
 
+// Mỗi hàng mang đủ dữ liệu cho một thẻ nhóm ở FE nên danh sách không cần
+// gọi thêm GET /groups/{id} cho từng nhóm (báo cáo đối chiếu mục 3.2, 3.3).
 func (q *Queries) ListActiveGroupsForUser(ctx context.Context, arg ListActiveGroupsForUserParams) ([]ListActiveGroupsForUserRow, error) {
 	rows, err := q.db.Query(ctx, listActiveGroupsForUser,
 		arg.UserID,
@@ -472,6 +490,9 @@ func (q *Queries) ListActiveGroupsForUser(ctx context.Context, arg ListActiveGro
 			&i.MembershipID,
 			&i.Role,
 			&i.ActiveMemberCount,
+			&i.CallerNetBalance,
+			&i.PendingBillCount,
+			&i.LastActivity,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/modules/group/repository/postgres/sqlc/querier.go
+++ b/internal/modules/group/repository/postgres/sqlc/querier.go
@@ -34,6 +34,8 @@ type Querier interface {
 	GetUserDisplayName(ctx context.Context, id pgtype.UUID) (string, error)
 	IncrementInviteUse(ctx context.Context, id pgtype.UUID) error
 	InsertMembership(ctx context.Context, arg InsertMembershipParams) (GroupMember, error)
+	// Mỗi hàng mang đủ dữ liệu cho một thẻ nhóm ở FE nên danh sách không cần
+	// gọi thêm GET /groups/{id} cho từng nhóm (báo cáo đối chiếu mục 3.2, 3.3).
 	ListActiveGroupsForUser(ctx context.Context, arg ListActiveGroupsForUserParams) ([]ListActiveGroupsForUserRow, error)
 	ListActiveMembers(ctx context.Context, groupID pgtype.UUID) ([]ListActiveMembersRow, error)
 	ListAvailableInvites(ctx context.Context, arg ListAvailableInvitesParams) ([]GroupInvite, error)


### PR DESCRIPTION
GET /groups nay trả đủ dữ liệu một thẻ nhóm trong một truy vấn, để màn
hình danh sách không phải gọi thêm GET /groups/{id} cho từng nhóm:

- caller_net_balance: số dư ròng VND của người gọi, trả dạng chuỗi để
  client không mất chính xác khi parse số lớn
- pending_bill_count: hóa đơn chưa chốt, cùng định nghĩa với rào chắn
  giải tán nhóm
- last_activity: hoạt động gần nhất, null khi nhóm chưa có hoạt động

Hoạt động gần nhất gói thành jsonb thay vì hai cột phẳng vì sqlc suy cột
phẳng lấy từ subquery thành NOT NULL và sẽ vỡ khi scan NULL.

Không thêm migration: cả ba đều là thay đổi truy vấn thuần, dùng lại
idx_bills_group_status và idx_group_activities_timeline có sẵn.

Bỏ qua backups/ vì database dump chứa email thật, hash mật khẩu và
token phiên.

Cập nhật docs/openapi.yaml. Kiểm chứng bằng integration test mới trên
ListActiveGroupsForUser.