### PR TITLE
feat: share one PostgreSQL LISTEN session and add River poll only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ HTTP_INVITE_ATTEMPTS_PER_MINUTE=30
 # PostgreSQL
 DATABASE_URL=postgres://postgres:postgres@localhost:5433/paysplit?sslmode=disable
 TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5433/paysplit_test?sslmode=disable
+DB_APPLICATION_NAME=paysplit-api
 DB_MAX_CONNS=10
 DB_MIN_CONNS=2
 DB_MAX_CONN_LIFETIME_MINUTES=60
@@ -56,6 +57,8 @@ MEDIA_CLEANUP_MAX_ATTEMPTS=10
 # River queue
 RIVER_WORKER_COUNT=5
 RIVER_FETCH_COOLDOWN_MS=100
+RIVER_POLL_ONLY=false
+RIVER_FETCH_POLL_INTERVAL_MS=1000
 
 # LlamaIndex OCR
 LLAMAINDEX_API_KEY=replace-with-llamaindex-api-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# PaySplit-BE
+
+Go 1.26 HTTP API (`paysplit-backend`). Entry: `cmd/api` → `internal/bootstrap/app.go` (the only wiring site). Companion apps: `PaySplit-FE` (Flutter), `PaySplit-RP` (product docs).
+
+Locked design lives in `docs/specs/`. Public contract: `docs/openapi.yaml`. Feature status: `docs/scope/scope.md`. Module write-ups: `docs/documents/`. Do not contradict a spec without updating it.
+
+## Commands
+
+```bash
+cp .env.example .env          # required: Makefile does `include .env` and will fail without it
+docker compose up -d postgres # Postgres 18 on host port 5433, not 5432
+make migrate-up               # goose against DATABASE_URL
+make run                      # go run ./cmd/api
+make test                     # go test ./... (exports .env)
+make sqlc                     # after editing queries/*.sql or adding a sqlc.yaml block
+make fmt                      # gofmt -w ./cmd ./internal  (no golangci-lint / no CI)
+
+go test ./internal/modules/bill/usecase/...
+go test -run TestLoad ./internal/config
+```
+
+`make goose-install` if `goose` is missing. No other task runner.
+
+## Env and startup
+
+- `config.Load` reads `.env` via godotenv; existing process env wins. Startup `Validate()` requires JWT, Gmail SMTP, Cloudinary, HTTPS `APP_INVITE_BASE_URL`, and **exact** auth TTLs: access 15m, refresh 168h, email/reset 10m. Changing those values will not boot.
+- FCM is optional (`FIREBASE_CREDENTIALS_*` empty → disabled). `fcm.New` returns a nil `*Notifier`; check the concrete pointer before assigning to an interface (typed-nil trap is documented in `bootstrap/app.go`).
+- `PORT` overrides `HTTP_PORT`. `HTTP_ADDRESS` overrides host:port.
+- River tables are auto-migrated at process start (`riverpkg.AutoMigrate`), not by goose. Register every worker **before** `river.NewClient`. `RIVER_WORKER_COUNT` must be `< DB_MAX_CONNS`.
+
+## Architecture
+
+Modules under `internal/modules/{auth,group,notification,bill,admin,settlement}`:
+
+```
+delivery/http → usecase → repository (port) → repository/postgres (adapter)
+                    ↓
+                 domain
+```
+
+- `domain`: entities + business errors only. No pgx/chi/http/sqlc.
+- `usecase`: interfaces + constructor injection. Never import `pgx`, `chi`, or `net/http`.
+- `repository/postgres/queries/*.sql` are hand-written. Generated code is `repository/postgres/sqlc/` — **never edit**. After a new module, add a **separate** block in `sqlc.yaml` (do not share `out` packages).
+- Shared infra: `internal/platform/`. Cross-module HTTP: `internal/transport/http/`.
+- New module: copy `auth` layout, add sqlc block, migrate, then construct + mount in `bootstrap/app.go` under `/api/v1`.
+
+## Database
+
+- Goose, one file per version: `db/migrations/NNNNNN_description.sql` with both `-- +goose Up` and `-- +goose Down`. Do **not** split into `.up.sql`/`.down.sql` (goose treats them as duplicate versions). `000001_init_schema.up.sql` is a historical exception; it still contains both sections.
+- Never edit an already-applied migration. Concurrent index changes use `-- +goose NO TRANSACTION`.
+- PKs: PostgreSQL 18 `uuidv7()`. Money: `BIGINT` / Go `int64` VND, no decimals.
+- Group-scoped writes take `database.LockActiveGroup` (or `Nowait`) **before** other row locks. Settlement/bill-void lock order: group → debts by UUID → payment.
+- sqlc `schema` is `./db/migrations` (goose Up sections).
+
+## HTTP
+
+- Prefix `/api/v1`. Success envelope: `{"success":true,"data":...,"message":"..."}` via `helpers.WriteJSON`. Errors: `helpers.WriteAPIError`. Health/metrics use `WriteRawJSON`.
+- `ReadJSON` rejects unknown fields; body cap is 64 KiB (multipart uploads are separate).
+- `middleware.Auth` = JWT + live session. `middleware.TokenAuth` = JWT only (sign-out). Use `middleware.UserID` / `UserRole`.
+- Global timeout 15s; paths ending in `/events` are exempt (route suffix only, not `Accept`). Invite preview/join uses a separate account+IP limiter (`HTTP_INVITE_ATTEMPTS_PER_MINUTE`), not the global IP limiter.
+- Rate limit keys use the TCP remote addr (`ClientIPFromRemoteAddr`), not forwarding headers.
+- 404/405 are JSON. Admin UI is embedded at `/admin-portal/` from `web/admin`.
+
+## Tests
+
+- `*_integration_test.go` skip unless `TEST_DATABASE_URL` is set. `.env.example` points at `paysplit_test` on 5433 — compose only creates `paysplit`; create/migrate the test DB yourself.
+- `make test` exports `.env`, so a set `TEST_DATABASE_URL` **runs** those tests (they will fail if that DB is missing). `go test ./...` without the env var skips them.
+- LlamaExtract / Cloudinary live tests skip without real credentials; they `godotenv.Load` the repo `.env` themselves.
+- Receipt fixtures under `testdata/bills/` are gitignored (personal data). Keep `service-account*.json` out of git.
+
+## Do not
+
+- Log proof URLs, VietQR refs, bank account numbers, or transfer notes.
+- Hand-edit `sqlc/` output.
+- Wire implementations outside `internal/bootstrap/app.go`.
+- Trust `X-Forwarded-For` for rate limits.
+- Bypass request timeout with `Accept: text/event-stream`.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ cp .env.example .env
 | `PORT` | rỗng | Port do nền tảng deploy cấp, được ưu tiên hơn `HTTP_PORT` |
 | `HTTP_ADDRESS` | `localhost:8080` | Tùy chọn gộp `host:port` (ghi đè nếu có) |
 | `DATABASE_URL` | `postgres://postgres:postgres@localhost:5433/paysplit?sslmode=disable` | Chuỗi kết nối PostgreSQL (port 5433 khi dùng docker compose) |
+| `DB_APPLICATION_NAME` | `paysplit-api` | Tên connection trong `pg_stat_activity`, nên đặt riêng cho từng instance khi đo connection |
 | `DB_MAX_CONNS` / `DB_MIN_CONNS` | `10` / `2` | Giới hạn số kết nối của pgx pool |
 | `DB_MAX_CONN_LIFETIME_MINUTES` | `60` | Thời gian sống tối đa của một kết nối trong pool |
 | `DB_MAX_CONN_IDLE_MINUTES` | `15` | Thời gian nhàn rỗi tối đa trước khi đóng kết nối |
@@ -123,6 +124,10 @@ cp .env.example .env
 | `CLOUDINARY_CLOUD_NAME` / `CLOUDINARY_API_KEY` / `CLOUDINARY_API_SECRET` | — | Cloudinary lưu avatar WebP |
 | `FIREBASE_CREDENTIALS_FILE` / `FIREBASE_CREDENTIALS_JSON` | — | Google Firebase Service Account credentials cho push notification FCM |
 | `FCM_TIMEOUT_SECONDS` | `5` | Thời gian timeout khi gửi tin FCM |
+| `RIVER_WORKER_COUNT` | `5` | Số worker River tối đa trên instance, phải nhỏ hơn `DB_MAX_CONNS` |
+| `RIVER_FETCH_COOLDOWN_MS` | `100` | Khoảng nghỉ tối thiểu giữa các lần River fetch job |
+| `RIVER_POLL_ONLY` | `false` | Bật polling và bỏ River notifier listener session sau khi restart |
+| `RIVER_FETCH_POLL_INTERVAL_MS` | `1000` | Chu kỳ tìm job khi River chạy poll only, phải không nhỏ hơn fetch cooldown |
 
 **2. Khởi động PostgreSQL**
 

--- a/docs/reviews/2026-09-03-dev.md
+++ b/docs/reviews/2026-09-03-dev.md
@@ -1,0 +1,45 @@
+# Review, dev, 2026-09-03
+
+**Reviewed by**: grok-4.6 (author on GPT)
+**Scope**: 17 code files, uncommitted working tree for connection efficient events
+**Verdict**: Changes requested
+
+## Summary
+
+The slice merges Bill and Group PostgreSQL listeners into one platform session, adds poll only River behind a flag, and closes local SSE subscribers when the shared listener drops. Routing, envelope checks, allowlisted metrics, dirty session Destroy, and poll config validation match spec 0010. The main gap is shutdown: `listenerCtx` is a child of the process signal context, so SIGTERM unlistens before HTTP drain and skips `CloseSubscribers`, which fights AC-9 order and can stall `Server.Shutdown` on live SSE streams.
+
+## Major
+
+### Shutdown cancels the listener before HTTP drain and does not close SSE, `internal/bootstrap/app.go:288`
+
+**Problem**: `listenerCtx` comes from `context.WithCancel(ctx)` where `ctx` is the process signal context. On SIGTERM that parent cancels immediately. `Run` then sees `ctx.Err()`, unlistens, and returns without calling `onDisconnect` (`internal/platform/database/notification_listener.go:130`). `Shutdown` still waits for SSE handlers that never saw `CloseSubscribers`.
+
+**Why it matters**: Spec AC-9 wants HTTP, then River, then the shared listener, then the pool. Spec AC-12 wants local Bill and Group streams closed when the listener goes away so clients reconnect for snapshot and `/sync`. Today the listener dies first, streams stay open, and `http.Server.Shutdown` can sit until the 10s timeout (or 15 minute max connection age) while clients hold a dead stream.
+
+**Suggested fix**: Give the listener a context that `Shutdown` cancels only after HTTP drain (or after an explicit `CloseSubscribers`). On process stop, close subscribers first so SSE handlers return, then stop River, then unlisten, then close the pool.
+
+## Minor
+
+### Shared shutdown context can starve later steps, `internal/bootstrap/app.go:352`
+
+HTTP `Shutdown`, River `Stop`, and the wait on `listenerDone` all share one timeout context. A slow drain leaves `ctx` already done, so the listener wait is skipped and `db.Close()` may cut a LISTEN session without `UNLISTEN *`. Timeout as a last resort is fine; splitting budgets would make the clean path more likely.
+
+### `clientConfig` silently defaults a non positive poll interval, `internal/platform/queue/river/client.go:67`
+
+Bootstrap `Validate` already rejects this. Direct `NewClient` callers would get 1s instead of an error. Harmless today, easy to confuse later.
+
+## Nits
+
+- `internal/platform/auth/jwt/access_token_manager.go:51`, comment only, not part of this slice
+- `internal/platform/banks/directory.go:43`, comment only
+- `internal/platform/image/avatar/processor.go`, comment only
+
+## Strengths
+
+- One listener, quoted `LISTEN` identifiers, Destroy on partial setup or failed `UNLISTEN *`, and allowlisted reconnect/payload metrics
+- Bill buffer 16 and Group buffer 32 are locked in tests; invalid envelopes omit raw payload; poll only scheduled, retry, and periodic jobs are covered
+- `RIVER_POLL_ONLY` defaults false so notifier rollback is config only
+
+## Test coverage
+
+Unit and integration tests cover routing, reconnect plus disconnect callback, dirty LISTEN, failed UNLISTEN, payload validation, buffer sizes, application_name, poll config, and River poll pickup. Missing: a shutdown test that proves SSE close and HTTP, River, listener order when the process context cancels.

--- a/docs/scope/scope.md
+++ b/docs/scope/scope.md
@@ -18,6 +18,7 @@ _These are recommendations to keep the build orderly. You decide when a feature 
 | 5   | Admin v1                             | Slice 5 | in-progress |
 | 6   | Notification and background queue v1 | Slice 6 | done        |
 | 7   | Group bill close v1                  | Slice 7 | in-progress |
+| 8   | Connection efficient events          | Slice 8 | in-progress |
 
 ## Slice 1: Identity and account
 
@@ -186,6 +187,27 @@ Provide a one way Captain lock that stops new bill submission for a group, an as
 - [ ] Document it: `/document group bill close v1`
 
 Spec [0008](../specs/0008-group-bill-close-v1/index.md) · code in `internal/modules/group/`, `internal/modules/bill/`, `internal/platform/metrics/`, and `internal/bootstrap/`
+
+## Slice 8: Connection efficient events
+
+### 8. Connection efficient events · in-progress
+
+Reduce long lived PostgreSQL sessions by sharing one listener between Bill and Group, and let River discover jobs through polling without a notifier listener session.
+
+**Done when:** all twelve acceptance criteria in spec 0010 pass, Bill and Group preserve their SSE contracts and recovery behavior, River poll only can be enabled per environment, and connection measurements distinguish `LISTEN` sessions, pinned pool slots, and total physical sessions.
+
+- [x] Design it (spec): `/architect connection efficient events`
+- [x] Build it: `/develop connection efficient events`
+  - [x] Shared listener lifecycle, readiness, safe cleanup, reconnect, and bounded shutdown (satisfies AC-1, AC-3, AC-9)
+  - [x] Bill and Group routing, validation, unchanged buffers, observability, and SSE recovery (satisfies AC-2, AC-4, AC-11, AC-12)
+  - [x] River poll only config, validation, rollback mode, and polling behavior (satisfies AC-5 through AC-8)
+  - [x] PostgreSQL integration coverage and connection measurement by application name (satisfies AC-1 through AC-12)
+- [x] Verify it: `/check verify connection efficient events`
+- [x] Test it: `/test connection efficient events`
+- [x] Review it (fresh model): `/check review connection efficient events`
+- [x] Document it: `/document connection efficient events`
+
+Spec [0010](../specs/0010-connection-efficient-events/index.md) · planned code in `internal/platform/database/`, `internal/platform/queue/river/`, `internal/modules/bill/delivery/http/`, `internal/modules/group/delivery/http/`, `internal/platform/metrics/`, `internal/config/`, and `internal/bootstrap/`
 
 ## Deferred
 

--- a/docs/specs/0010-connection-efficient-events/0001-shared-postgres-listener.md
+++ b/docs/specs/0010-connection-efficient-events/0001-shared-postgres-listener.md
@@ -1,0 +1,39 @@
+# 0001. Shared PostgreSQL listener
+
+## Summary
+
+Bill và Group dùng một PostgreSQL connection để nhận hai channel. Platform dispatch payload thô theo channel, còn mỗi module giữ kiểu event, validation, subscriber buffer, và quy tắc publish riêng.
+
+## Requirements
+
+1. Một connection chạy cả `LISTEN bill_events` và `LISTEN group_events`.
+2. Event cùng channel giữ đúng thứ tự nhận.
+3. Startup chỉ ready sau khi đăng ký đủ hai channel. Runtime disconnect chuyển readiness sang degraded và reconnect đăng ký lại đủ hai channel.
+4. Bill payload yêu cầu `BillID != uuid.Nil` và `Type` không rỗng. Group payload yêu cầu `GroupID != uuid.Nil`, `Version > 0`, và `Type` không rỗng.
+5. Lỗi payload chỉ bỏ một notification, không log raw payload, và không làm reconnect listener.
+6. Khi listener disconnect, local SSE subscription được đóng để Bill phục hồi bằng snapshot và Group phục hồi bằng version fencing cùng `/sync`.
+7. Bill giữ subscriber buffer `16`; Group giữ subscriber buffer `32`.
+8. API và SSE contract không đổi.
+
+## Decision
+
+Tạo listener dùng chung tại `internal/platform/database/notification_listener.go`, với registry handler bất biến. Dispatch chạy đồng bộ vì handler chỉ decode và publish không blocking. Cách này giữ thứ tự Group version và không tạo dependency từ platform vào module.
+
+Bill export `billhttp.NotificationChannel`, tiếp tục dùng pool cho outbound `pg_notify`, và không còn listener loop. Group export `grouphttp.NotificationChannel`, giữ decode và publish, và không còn giữ `pgxpool.Pool`. Bootstrap sở hữu lifecycle của listener chung.
+
+Reconnect backoff bắt đầu `500 ms`, nhân đôi tới tối đa `30 s`, có jitter từ `80%` đến `120%`, và reset sau `30 s` healthy liên tục. Clean shutdown chạy `UNLISTEN *` trước khi release. Nếu setup chỉ hoàn tất một phần, wait lỗi, hoặc cleanup lỗi, underlying connection bị đóng để session có trạng thái `LISTEN` không trở lại pool.
+
+## Build plan
+
+1. Định nghĩa listener, handler registry, initial readiness gate, runtime degraded state, reconnect backoff, bounded shutdown, và metrics.
+2. Tách Bill decode, semantic validation, và publish thành handler, giữ subscriber buffer `16`.
+3. Tách Group decode, semantic validation, và publish thành handler, giữ subscriber buffer `32`.
+4. Export channel constant từ hai module, wire một listener trong bootstrap, và xóa hai loop cũ.
+5. Đóng local SSE subscription khi listener disconnect để kích hoạt recovery flow hiện có.
+6. Thêm unit test và PostgreSQL integration test cho routing, ordering, invalid payload, reconnect, partial `LISTEN`, `UNLISTEN *`, pool contamination, readiness, recovery, và shutdown timeout.
+7. Đo riêng số `LISTEN` session, pinned pool slot, và total physical session trước và sau.
+
+## Rollback
+
+Revert wiring về hai listener cũ. Không chạy hai kiến trúc cùng lúc vì cùng event có thể được publish hai lần trong một instance.
+

--- a/docs/specs/0010-connection-efficient-events/0002-river-poll-only.md
+++ b/docs/specs/0010-connection-efficient-events/0002-river-poll-only.md
@@ -1,0 +1,35 @@
+# 0002. River poll only
+
+## Summary
+
+River bỏ notifier listener connection và tìm job mới bằng polling. Mặc định một giây cân bằng giữa connection budget, database load, và độ trễ OCR hoặc notification.
+
+## Requirements
+
+1. `RIVER_POLL_ONLY=true` không tạo River notifier connection hoặc chạy `LISTEN`. River vẫn có thể gửi `NOTIFY` khi enqueue.
+2. `RIVER_POLL_ONLY=false` là mặc định để rollout hai phase độc lập.
+3. `RIVER_FETCH_POLL_INTERVAL_MS=1000` là mặc định.
+4. Poll interval phải dương và không nhỏ hơn fetch cooldown mặc định `100 ms`.
+5. Transactional enqueue, retry, scheduled jobs, periodic jobs, và graceful shutdown không đổi.
+6. `RIVER_POLL_ONLY=false` khôi phục notifier sau khi restart.
+7. Với queue idle, worker sẵn sàng, và database khỏe, commit đến lần fetch tiếp theo có miền lý thuyết từ `0 ms` đến dưới `1100 ms`. Test end to end phải thêm tolerance cho runtime và database.
+
+## Decision
+
+Mở rộng config nội bộ của River wrapper với `PollOnly` và `FetchPollInterval`. Giá trị được chuyển thẳng vào `river.Config`. Giữ `FetchCooldown` riêng vì nó điều khiển tốc độ fetch khi queue đang có việc, không phải nhịp polling khi queue rảnh.
+
+Thêm `DB_APPLICATION_NAME`, mặc định `paysplit-api`, vào PostgreSQL connection config. Verification dùng một application name duy nhất cho instance thử nghiệm để `pg_stat_activity` đếm được cả pooled session và River session đã hijack.
+
+## Build plan
+
+1. Thêm `RIVER_POLL_ONLY` mặc định `false`, `RIVER_FETCH_POLL_INTERVAL_MS`, và `DB_APPLICATION_NAME` vào config loader, validation, `.env.example`, và README.
+2. Mở rộng River wrapper và bootstrap wiring.
+3. Thêm unit test cho default, override, và validation.
+4. Thêm integration test chứng minh job được nhận bằng polling với timing tolerance và các loại job định kỳ vẫn chạy.
+5. Log mode và poll interval khi startup.
+6. Bật `RIVER_POLL_ONLY=true` theo từng môi trường và đo notifier session, total physical session, queue wait, và queue depth.
+
+## Rollback
+
+Đặt `RIVER_POLL_ONLY=false` rồi restart process. Không cần đổi code hoặc migration.
+

--- a/docs/specs/0010-connection-efficient-events/index.md
+++ b/docs/specs/0010-connection-efficient-events/index.md
@@ -1,0 +1,191 @@
+# 0010. Connection efficient events
+
+**Date**: 2026-09-03
+**Status**: In Progress
+
+## Summary
+
+PaySplit giảm ba PostgreSQL `LISTEN` session xuống còn một session trên mỗi backend instance. Bill và Group dùng chung một listener cho hai channel. River chuyển sang poll only để bỏ notifier session dài hạn, với thời gian polling mặc định một giây và khả năng quay lại notifier bằng cấu hình.
+
+Mức giảm tổng physical connection còn phụ thuộc `DB_MIN_CONNS` và tải thực tế. Vì vậy verification phải đo riêng số `LISTEN` session, số pool slot bị giữ lâu, và tổng physical session.
+
+## Structure
+
+1. [Shared PostgreSQL listener](0001-shared-postgres-listener.md) quy định một connection nhận cả `bill_events` và `group_events`.
+2. [River poll only](0002-river-poll-only.md) quy định River không tạo notifier connection và tìm job mới bằng polling.
+
+## Requirements
+
+### User stories
+
+1. Là người vận hành, tôi muốn mỗi backend instance dùng ít connection sống lâu hơn để giảm áp lực lên Supavisor.
+2. Là người dùng, tôi muốn Bill SSE và Group SSE giữ nguyên hành vi khi hạ tầng listener được hợp nhất.
+3. Là hệ thống, tôi muốn River vẫn xử lý job bền vững khi PostgreSQL `LISTEN/NOTIFY` không được dùng để đánh thức queue.
+
+### Acceptance criteria
+
+1. **AC-1**: Một backend instance chỉ giữ một PostgreSQL connection để `LISTEN bill_events` và `LISTEN group_events`.
+2. **AC-2**: Notification của mỗi channel chỉ đến đúng Hub và giữ đúng thứ tự nhận. Event schema, SSE endpoint, snapshot, heartbeat, version fencing, và cơ chế bỏ event cho client chậm không thay đổi. Bill giữ subscriber buffer `16`; Group giữ subscriber buffer `32`.
+3. **AC-3**: Startup chỉ báo ready sau khi listener acquire connection và đăng ký thành công cả hai channel. Khi connection bị đóng trong runtime, readiness chuyển sang degraded, listener kết nối lại với exponential backoff có jitter, đăng ký lại cả hai channel, rồi mới trở lại healthy.
+4. **AC-4**: Bill payload chỉ hợp lệ khi decode thành công, `BillID != uuid.Nil`, và `Type` không rỗng. Group payload chỉ hợp lệ khi decode thành công, `GroupID != uuid.Nil`, `Version > 0`, và `Type` không rỗng. Payload lỗi chỉ bị bỏ cho notification đó, được ghi nhận bằng log và metric có cardinality giới hạn, không được log nguyên văn, và không làm reconnect listener.
+5. **AC-5**: Khi `RIVER_POLL_ONLY=true`, River không tạo notifier connection và không phát câu lệnh `LISTEN`. River vẫn có thể gửi `NOTIFY` trong đường enqueue của thư viện, nhưng không giữ listener session. Job mới được phát hiện bằng polling với `RIVER_FETCH_POLL_INTERVAL_MS=1000` mặc định.
+6. **AC-6**: Poll interval phải dương và không được nhỏ hơn `RIVER_FETCH_COOLDOWN_MS`. Cấu hình sai làm startup thất bại với tên biến rõ ràng.
+7. **AC-7**: Khi queue đang rảnh, worker sẵn sàng, và database khỏe, thời gian từ lúc transaction enqueue commit đến lần fetch kế tiếp có miền lý thuyết từ `0 ms` đến dưới `1100 ms` với interval mặc định và jitter của River. Test dùng tolerance riêng cho thời gian chạy và database thay vì coi `1100 ms` là hard upper bound của end to end latency.
+8. **AC-8**: `RIVER_POLL_ONLY=false` khôi phục notifier hiện tại sau khi restart process, không cần đổi code hoặc migration.
+9. **AC-9**: Graceful shutdown dừng HTTP, River, shared listener, rồi pool trong thời gian chờ hữu hạn. Clean path chạy `UNLISTEN *` trước khi release connection. Session chưa đăng ký đủ channel hoặc cleanup lỗi phải bị đóng thay vì trả về pool.
+10. **AC-10**: Ở trạng thái idle, số `LISTEN` session của ứng dụng giảm từ ba xuống một và số pool slot bị Bill hoặc Group listener giữ giảm từ hai xuống một. Tổng physical session được báo cáo riêng vì phụ thuộc `DB_MIN_CONNS` và tải. Với cấu hình hiện tại `DB_MIN_CONNS=0`, mục tiêu idle xấp xỉ từ ba xuống một physical session.
+11. **AC-11**: Không có migration, thay đổi OpenAPI, hoặc thay đổi payload công khai.
+12. **AC-12**: Khi shared listener mất connection, các local Bill và Group SSE subscription hiện có được đóng để client reconnect. Bill phục hồi bằng snapshot; Group phục hồi bằng version fencing và `/sync`, tránh giữ stream sống nhưng bỏ lỡ notification trong khoảng disconnect.
+
+## Decision
+
+**Chosen option**: Một shared listener tại platform layer và River poll only có feature flag.
+
+Shared listener sở hữu một connection và một registry handler cố định được hoàn tất trước khi start. Handler nhận payload thô theo channel, giải mã trong module tương ứng, rồi publish đồng bộ để giữ thứ tự. River nhận `PollOnly` và `FetchPollInterval` qua wrapper hiện có. `RIVER_POLL_ONLY` mặc định `false` để hai phase rollout có thể được kiểm chứng độc lập trước khi bật poll only theo từng môi trường.
+
+**Implementation skills**: `supabase` (`supabase`, `.agents/skills/supabase/`) · `supabase-postgres-best-practices` (`supabase/agent-skills`, `.agents/skills/supabase-postgres-best-practices/`)
+
+## Feature design
+
+### Components
+
+1. `PostgresNotificationListener` nằm tại `internal/platform/database/notification_listener.go`. Nó sở hữu pool reference, một connection đang acquire, danh sách channel bất biến, vòng reconnect, readiness, và metrics.
+2. Mỗi handler có chữ ký tương đương `func(context.Context, string) error`. Platform không import kiểu dữ liệu của Bill hoặc Group.
+3. Bill Hub giữ subscriber buffer `16`, phần publish subscriber, và đường phát `pg_notify`, nhưng không còn sở hữu listener loop.
+4. Group Hub giữ subscriber buffer `32`, phần publish subscriber, và giải mã event, nhưng không còn giữ `pgxpool.Pool`.
+5. Bill và Group export `billhttp.NotificationChannel` và `grouphttp.NotificationChannel`. Bootstrap dùng hai constant này để tạo registry, rồi start đúng một shared listener goroutine.
+6. River wrapper mở rộng config với `PollOnly` và `FetchPollInterval` rồi chuyển nguyên giá trị vào `river.Config`.
+
+### Lifecycle
+
+1. Bootstrap tạo pool và các Hub.
+2. Bootstrap tạo registry listener cố định.
+3. Shared listener acquire một connection và chạy đủ hai câu lệnh `LISTEN` trước khi application báo ready.
+4. River start theo mode từ env.
+5. Listener chờ notification và dispatch đồng bộ theo thứ tự nhận.
+6. Khi listener disconnect, readiness degraded và local SSE subscription được đóng trước khi reconnect.
+7. Shutdown dừng HTTP, River, và shared listener trong thời gian chờ hữu hạn trước khi đóng pool.
+
+### Failure handling
+
+1. Lỗi acquire, `LISTEN`, hoặc wait đưa listener về trạng thái unhealthy và kích hoạt reconnect. Backoff bắt đầu `500 ms`, nhân đôi tới tối đa `30 s`, áp dụng jitter từ `80%` đến `120%`, và reset sau `30 s` healthy liên tục.
+2. Reconnect luôn tạo session mới và đăng ký lại toàn bộ channel.
+3. Decode hoặc semantic validation lỗi chỉ loại một notification, không reconnect.
+4. Handler chạy đồng bộ và phải hoàn tất nhanh. Publish tới SSE subscriber tiếp tục dùng channel buffer không blocking.
+5. Clean shutdown chạy `UNLISTEN *` rồi release. Lỗi trong partial setup, wait, hoặc cleanup làm underlying connection bị đóng để session có trạng thái `LISTEN` không quay lại pool.
+6. Khi listener disconnect, Hub đóng local SSE subscription. Bill client reconnect để lấy snapshot hiện tại. Group client reconnect với version fencing và gọi `/sync` khi có khoảng trống version.
+
+### Value sourcing
+
+1. Danh sách channel đến từ registry được bootstrap tạo từ `billhttp.NotificationChannel` và `grouphttp.NotificationChannel`.
+2. Raw payload và channel đến từ `pgconn.Notification`.
+3. Poll only đến từ `RIVER_POLL_ONLY`.
+4. Poll interval đến từ `RIVER_FETCH_POLL_INTERVAL_MS`.
+5. Fetch cooldown tiếp tục đến từ `RIVER_FETCH_COOLDOWN_MS`.
+6. Application name đến từ `DB_APPLICATION_NAME` và được gắn vào PostgreSQL connection config.
+7. Connection count đến từ Supabase Database Connections hoặc `pg_stat_activity`, lọc theo một `DB_APPLICATION_NAME` duy nhất cho instance thử nghiệm để bao gồm cả pooled session và River session đã hijack.
+
+### Key invariants
+
+1. Chỉ một goroutine được gọi `WaitForNotification` trên shared connection.
+2. Registry không thay đổi sau khi listener start.
+3. Notification của cùng một channel được dispatch theo đúng thứ tự nhận.
+4. Platform layer không phụ thuộc Bill hoặc Group.
+5. Bill subscriber buffer luôn là `16`; Group subscriber buffer luôn là `32`.
+6. Connection chỉ được release về pool sau khi `UNLISTEN *` thành công. Mọi cleanup path không chắc chắn phải đóng underlying connection.
+7. `FetchPollInterval >= FetchCooldown`.
+8. Poll only không thay đổi transactional enqueue, retry, scheduling, periodic jobs, hoặc graceful shutdown của River.
+
+### Security model
+
+Không có surface công khai mới. Listener không log payload, thông tin hóa đơn, thông tin nhóm, hoặc dữ liệu ngân hàng. Database credential tiếp tục chỉ đến từ `DATABASE_URL`.
+
+### Configuration required
+
+1. `RIVER_POLL_ONLY`: bật poll only, mặc định `false`.
+2. `RIVER_FETCH_POLL_INTERVAL_MS`: thời gian River tìm job khi queue đang rảnh, mặc định `1000`.
+3. `RIVER_FETCH_COOLDOWN_MS`: thời gian nghỉ giữa các lần fetch khi queue đang có việc, giữ mặc định `100`.
+4. `DB_APPLICATION_NAME`: tên ổn định để quan sát connection, mặc định `paysplit-api`.
+
+### Observability
+
+1. Gauge `paysplit_db_listener_connected` có giá trị `0` hoặc `1`.
+2. Counter `paysplit_db_listener_reconnects_total{reason}` chỉ nhận `reason` thuộc allowlist `acquire`, `listen`, `wait`.
+3. Counter `paysplit_db_listener_invalid_payloads_total{channel}` chỉ nhận `channel` thuộc allowlist `bill_events`, `group_events`.
+4. Reconnect log có `channel`, `reason`, `attempt`, và `backoff`. Invalid payload log có `channel` và validation reason nhưng không có raw payload.
+5. Startup log ghi River mode và poll interval, không ghi `DATABASE_URL`.
+6. Verification ghi riêng `LISTEN` session, pinned pool slot, và total physical session trước và sau trên cùng một instance idle.
+
+### Critical test scenarios
+
+1. Gửi xen kẽ event Bill và Group, xác nhận đúng Hub, đúng thứ tự, và buffer giữ nguyên, kiểm chứng **AC-1**, **AC-2**.
+2. Đóng connection listener, xác nhận readiness degraded, subscription hiện có bị đóng, cả hai channel được đăng ký lại, và client phục hồi qua snapshot hoặc `/sync`, kiểm chứng **AC-3**, **AC-12**.
+3. Gửi payload lỗi cho từng rule semantic rồi gửi payload hợp lệ trên channel kia, xác nhận metric, log redaction, và listener không reconnect, kiểm chứng **AC-4**.
+4. Làm lỗi câu lệnh `LISTEN` thứ hai và lỗi `UNLISTEN *`, xác nhận connection bị đóng và session có trạng thái `LISTEN` không quay lại pool, kiểm chứng **AC-9**.
+5. Bật poll only, enqueue job trong transaction, và xác nhận worker fetch bằng polling với tolerance cho runtime, kiểm chứng **AC-5**, **AC-7**.
+6. Tắt poll only và restart, xác nhận River notifier hoạt động lại, kiểm chứng **AC-8**.
+7. Hủy context khi listener và River đang idle, xác nhận shutdown hoàn tất trong timeout và không còn goroutine hoặc connection, kiểm chứng **AC-9**.
+8. Đo `LISTEN` session, pinned pool slot, và total physical session trước và sau bằng cùng application name, kiểm chứng **AC-10**.
+
+## Build plan
+
+1. Thêm `DB_APPLICATION_NAME` vào config và PostgreSQL connection setup. Ghi baseline theo ba phép đo trước khi thay đổi, kiểm chứng đầu vào cho **AC-10**.
+2. Xây shared listener với initial readiness gate, runtime degraded state, backoff đã định nghĩa, bounded shutdown, và cleanup không trả session bẩn về pool, thỏa **AC-1**, **AC-3**, **AC-9**.
+3. Tách Bill và Group handler với semantic validation, constant channel export, subscriber buffer giữ nguyên, metric, và log redaction, thỏa **AC-2**, **AC-4**, **AC-11**.
+4. Wire một listener trong bootstrap, xóa hai listener loop cũ, và đóng local SSE subscription khi shared listener disconnect, thỏa **AC-1**, **AC-3**, **AC-12**.
+5. Chạy unit test và PostgreSQL integration test cho routing, ordering, reconnect, partial `LISTEN`, cleanup, pool contamination, cancellation, và recovery của client, thỏa **AC-1** đến **AC-4**, **AC-9**, **AC-12**.
+6. Thêm `RIVER_POLL_ONLY` mặc định `false` và `RIVER_FETCH_POLL_INTERVAL_MS` vào config, validation, `.env.example`, và README, thỏa **AC-5**, **AC-6**, **AC-8**.
+7. Truyền poll config qua River wrapper và thêm test cho poll only, notifier rollback sau restart, pickup latency có tolerance, scheduled jobs, và periodic jobs, thỏa **AC-5** đến **AC-9**.
+8. Thêm metrics và structured logs theo tên và allowlist đã định nghĩa, thỏa **AC-3**, **AC-4**, **AC-10**.
+9. Chạy test liên quan, test toàn repo, rồi đo lại ba loại connection trên một instance idle và dưới queue load, thỏa **AC-2**, **AC-7**, **AC-9**, **AC-10**, **AC-11**.
+10. Triển khai shared listener trước với River notifier giữ nguyên. Sau khi ổn định, bật `RIVER_POLL_ONLY=true` ở development, staging, rồi production. Quan sát reconnect, readiness, queue latency, queue depth, và ba phép đo connection tại mỗi bước, thỏa **AC-3**, **AC-7**, **AC-8**, **AC-10**, **AC-12**.
+
+## Consequences
+
+### Positive
+
+1. Mỗi instance giải phóng hai `LISTEN` session dài hạn. Mức giảm total physical connection phụ thuộc `DB_MIN_CONNS` và tải.
+2. Bill và Group dùng chung một cơ chế reconnect và observability.
+3. River tương thích với môi trường không hỗ trợ `LISTEN/NOTIFY` để đánh thức queue.
+
+### Negative
+
+1. Job mới có thêm tối đa khoảng một polling window trước khi được nhận.
+2. Polling tạo query đều đặn khi queue rảnh.
+3. Shared listener là failure domain chung của hai channel. Disconnect buộc cả hai loại SSE client reconnect để phục hồi trạng thái.
+4. Khi River leader dừng, poll only có thể mất tối đa khoảng năm giây để một client khác nhận leadership.
+
+### Neutral
+
+1. Không đổi schema hoặc API.
+2. River vẫn dùng cùng pool cho query và worker transaction.
+3. River có thể tiếp tục gửi `NOTIFY` khi enqueue dù poll only đã bỏ notifier listener session.
+
+## Migration plan
+
+**Strategy**: Hai phase độc lập với rollback bằng cấu hình cho River.
+
+### Phases
+
+1. Triển khai shared listener, giữ `RIVER_POLL_ONLY=false`, và đo mức giảm một `LISTEN` session.
+2. Bật `RIVER_POLL_ONLY=true` theo từng môi trường và đo mức giảm notifier session cùng queue latency.
+
+### Rollback
+
+1. Shared listener rollback bằng revert phase một. Không chạy listener cũ và mới đồng thời vì sẽ phát trùng event.
+2. River rollback bằng `RIVER_POLL_ONLY=false` rồi restart process, không cần đổi code hoặc migration.
+
+### Risks
+
+1. Handler chậm có thể trì hoãn channel còn lại. Thiết kế giới hạn handler ở decode và publish không blocking.
+2. Poll interval quá nhỏ làm tăng database load. Validation giữ interval không thấp hơn cooldown và mặc định là một giây.
+3. Poll interval quá lớn làm OCR và notification có cảm giác chậm. Metric queue wait phải được theo dõi trước khi tăng interval.
+4. PostgreSQL không lưu notification trong thời gian listener disconnect. Đóng local SSE subscription buộc client dùng recovery flow thay vì tiếp tục trên stream đã mất event.
+
+## Follow up
+
+1. Sau khi production ổn định, đánh giá giảm `DB_MAX_CONNS` và `RIVER_WORKER_COUNT` dựa trên connection peak và queue depth thực tế.
+
+## Rationale
+
+Reasoning and options: see [rationale.md](rationale.md).

--- a/docs/specs/0010-connection-efficient-events/rationale.md
+++ b/docs/specs/0010-connection-efficient-events/rationale.md
@@ -1,0 +1,42 @@
+# Rationale: 0010 Connection efficient events
+
+## Context
+
+Mỗi backend instance hiện có hai listener riêng cho Bill và Group. River tạo thêm notifier bằng một connection được tách khỏi pgx pool sau khi acquire. Ba session này sống lâu trên Supavisor session mode. Tổng physical session còn phụ thuộc `DB_MIN_CONNS`, `DB_MAX_CONNS`, tải HTTP, và tải worker nên không được suy ra chỉ từ pool limit.
+
+Bill và Group đều cần PostgreSQL `LISTEN/NOTIFY`, nhưng cơ chế acquire, wait, reconnect, và shutdown đang bị lặp. River đã hỗ trợ poll only chính thức, nên notifier listener riêng không còn bắt buộc. Poll only có thể vẫn gửi `NOTIFY` khi enqueue, nhưng không giữ session để nhận notification.
+
+Mục tiêu là giảm connection mà không đổi transactional enqueue, SSE contract, Group version fencing, hoặc tính bền vững của queue.
+
+## Options considered
+
+### Option 1. Giữ nguyên kiến trúc và chỉ giảm pool limit
+
+Pool cap thấp hơn không loại các session sống lâu. Cách này còn tăng nguy cơ HTTP và worker chờ connection.
+
+### Option 2. Chỉ bật River poll only
+
+Cách này là thay đổi nhỏ nhất và bỏ một notifier session, nhưng Bill và Group vẫn giữ hai listener riêng cùng code lifecycle bị lặp.
+
+### Option 3. Chỉ gộp Bill và Group
+
+Cách này giảm một `LISTEN` session và loại code lặp, nhưng River vẫn giữ notifier listener session.
+
+### Option 4. Shared listener và River poll only
+
+Cách này giảm hai `LISTEN` session trên mỗi instance, giữ toàn bộ dữ liệu trong PostgreSQL, và có rollback riêng cho River. Đổi lại, job mới chịu thêm tối đa khoảng một polling window và database nhận query polling đều đặn.
+
+Transaction pooling không phải một option thay thế trực tiếp vì `LISTEN/NOTIFY` cần session state. PaySplit vẫn cần direct hoặc session connection cho realtime ngay cả khi các query khác dùng transaction pooler.
+
+## Rationale
+
+Option 4 giải quyết đúng hai listener session dư thừa mà không thêm hạ tầng. Shared listener giữ nguyên module event types và public contract. River poll only là khả năng sẵn có của thư viện đang dùng, nên rủi ro thấp hơn việc tự xây queue wakeup.
+
+Hai phần được triển khai riêng để mỗi bước có baseline, verification, và rollback độc lập. Shared listener không dùng feature flag vì chạy song song sẽ tạo event trùng. River dùng env flag, mặc định `false`, vì hai mode có thể thay thế nhau an toàn sau restart.
+
+## Related decisions
+
+1. `docs/specs/0003-bill-ocr-v1/` quy định Bill SSE và snapshot recovery.
+2. `docs/specs/0006-notification-queue-v1/` quy định River, transactional enqueue, và graceful shutdown.
+3. `docs/specs/0009-group-realtime-sync-v1/` quy định Group SSE, version fencing, và `/sync` recovery.
+

--- a/docs/specs/0010-connection-efficient-events/verify.md
+++ b/docs/specs/0010-connection-efficient-events/verify.md
@@ -1,0 +1,43 @@
+# Verify: Connection efficient events · spec 0010 · updated 2026-09-03
+
+_Steps derived from spec 0010 acceptance criteria. `/check verify` runs these; `/test` locks the durable ones._
+
+## Runtime and database
+
+- [x] Start one backend instance with a unique `DB_APPLICATION_NAME`, `RIVER_POLL_ONLY=false`, and a healthy PostgreSQL database. Query `pg_stat_activity` by that application name and record the total physical sessions, acquired pool slots, and three idle sessions whose last query is `LISTEN` → AC-10
+- [x] Send interleaved valid notifications to `bill_events` and `group_events`. Confirm one shared listener session receives both, each notification reaches only its matching Hub, same channel ordering is preserved, Bill subscriber capacity remains `16`, and Group subscriber capacity remains `32` → AC-1, AC-2
+- [x] Terminate the shared listener backend connection while Bill and Group SSE clients are connected. Confirm `/health/ready` returns `503`, both existing streams close, the listener reconnects with bounded backoff, both channels are registered before readiness returns `200`, Bill reloads its snapshot, and Group recovers through version fencing plus `/sync` → AC-3, AC-12
+- [x] Send malformed JSON and semantic failures for each channel. Cover missing Bill ID, missing Bill type, missing Group ID, nonpositive Group version, and missing Group type. Confirm each notification is dropped, the other channel continues, the invalid payload counter increments only for the allowed channel, and no raw payload appears in logs → AC-4
+- [x] Stop the backend gracefully while the listener is idle. Confirm River stops before the listener, the listener runs `UNLISTEN *`, the connection returns cleanly to the pool, shutdown respects its timeout, and no listener goroutine or acquired connection remains → AC-9
+- [ ] Force the second `LISTEN` command or `UNLISTEN *` cleanup to fail in an isolated test database. Confirm the underlying connection is closed and never returned to the pool with session state attached → AC-9
+
+## River polling
+
+- [x] Start with `RIVER_POLL_ONLY=true`, `RIVER_FETCH_COOLDOWN_MS=100`, and `RIVER_FETCH_POLL_INTERVAL_MS=1000`. Confirm startup logs show poll only mode and the resolved interval without exposing `DATABASE_URL` → AC-5, AC-11
+- [x] Query `pg_stat_activity` using the instance `DB_APPLICATION_NAME`. Confirm the shared Bill and Group listener is the only application `LISTEN` session and River has no notifier listener session. River may still execute `NOTIFY` during enqueue → AC-5, AC-10
+- [x] Enqueue a job inside a transaction, verify it cannot run before commit, then commit while the queue is idle. Confirm River starts it through polling. Record commit to fetch latency against the theoretical `0 ms` to under `1100 ms` window and apply a separate test tolerance for runtime and database delay → AC-5, AC-7
+- [ ] Verify retry, scheduled jobs, periodic jobs, and transactional enqueue behave as before while poll only is enabled → AC-5, AC-7
+- [x] Set `RIVER_FETCH_POLL_INTERVAL_MS=0`, then set it below `RIVER_FETCH_COOLDOWN_MS`. Confirm startup fails and names `RIVER_FETCH_POLL_INTERVAL_MS` and `RIVER_FETCH_COOLDOWN_MS` in the validation error → AC-6
+- [x] Set `RIVER_POLL_ONLY=false` and restart the process. Confirm the River notifier listener session returns without code changes or database migration → AC-8
+
+## Commands
+
+- [x] `go test -race ./internal/platform/database ./internal/modules/bill/delivery/http ./internal/modules/group/delivery/http ./internal/platform/queue/river ./internal/config ./internal/platform/metrics ./internal/transport/http/router ./internal/bootstrap` → all packages pass → AC-1 through AC-9, AC-11, AC-12
+- [x] `TEST_DATABASE_URL=<isolated-postgres-url> go test -count=1 -run Integration ./internal/platform/database ./internal/platform/queue/river` → both integration suites pass and connection assertions match → AC-1, AC-2, AC-5, AC-7, AC-9, AC-10
+- [x] `go test ./...` → the complete backend suite passes with live provider credentials disabled unless those integrations are intentionally under test → AC-2, AC-5, AC-8, AC-9, AC-11
+- [x] `git diff --check` and `rg -n 'StartPostgresListener|func \(h \*Hub\) listenLoop' internal/modules internal/bootstrap` → clean diff and no legacy listener loop remains → AC-1, AC-9, AC-11
+
+## Acceptance criteria coverage
+
+- AC-1 is covered by runtime steps 1 and 2, plus integration commands.
+- AC-2 is covered by runtime step 2 and the complete backend suite.
+- AC-3 is covered by runtime step 3.
+- AC-4 is covered by runtime step 4.
+- AC-5 is covered by River steps 1 through 4.
+- AC-6 is covered by River step 5.
+- AC-7 is covered by River steps 3 and 4.
+- AC-8 is covered by River step 6.
+- AC-9 is covered by runtime steps 5 and 6, plus race tests.
+- AC-10 is covered by runtime step 1 and River step 2.
+- AC-11 is covered by runtime and command comparison steps.
+- AC-12 is covered by runtime step 3.

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -59,11 +59,14 @@ import (
 // App đại diện cho ứng dụng API đã được khởi tạo và sở hữu HTTP server cùng
 // database pool và job queue; các tài nguyên này phải được giải phóng khi ứng dụng dừng.
 type App struct {
-	server        *http.Server
-	db            *pgxpool.Pool
-	riverClient   *river.Client[pgx.Tx]
-	cancelWorkers context.CancelFunc
-	workers       sync.WaitGroup
+	server         *http.Server
+	db             *pgxpool.Pool
+	riverClient    *river.Client[pgx.Tx]
+	closeSSE       func()
+	cancelWorkers  context.CancelFunc
+	cancelListener context.CancelFunc
+	listenerDone   <-chan struct{}
+	workers        sync.WaitGroup
 }
 
 // New khởi tạo ứng dụng API bằng cách:
@@ -203,9 +206,11 @@ func New(ctx context.Context) (*App, error) {
 	periodicJobs := append(billPeriodicJobs, settlementPeriodicJobs...)
 
 	riverClient, err := riverpkg.NewClient(db, riverWorkers, riverpkg.Config{
-		MaxWorkers:    cfg.River.WorkerCount,
-		FetchCooldown: cfg.River.FetchCooldown,
-		PeriodicJobs:  periodicJobs,
+		MaxWorkers:        cfg.River.WorkerCount,
+		FetchCooldown:     cfg.River.FetchCooldown,
+		PollOnly:          cfg.River.PollOnly,
+		FetchPollInterval: cfg.River.FetchPollInterval,
+		PeriodicJobs:      periodicJobs,
 	})
 	if err != nil {
 		db.Close()
@@ -234,8 +239,24 @@ func New(ctx context.Context) (*App, error) {
 	groupHandler := grouphttp.NewHandler(groupService, avatarStore.URL)
 	// Hub nhóm nhận sự kiện qua pg_notify do chính transaction của mutation phát,
 	// nên nó chỉ cần lắng nghe — không có đường phát nào đi vòng qua nhật ký.
-	groupHub := grouphttp.NewHub(db)
+	groupHub := grouphttp.NewHub()
 	groupSSEHandler := grouphttp.NewSSEHandler(groupHandler, groupHub, cfg.GroupSync.HeartbeatInterval, cfg.GroupSync.MaxConnectionAge)
+	closeSSE := func() {
+		billHub.CloseSubscribers()
+		groupHub.CloseSubscribers()
+	}
+	sharedListener, err := database.NewPostgresNotificationListener(
+		db,
+		map[string]database.NotificationHandler{
+			billhttp.NotificationChannel:  billHub.HandlePostgresNotification,
+			grouphttp.NotificationChannel: groupHub.HandlePostgresNotification,
+		},
+		closeSSE,
+	)
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("create shared PostgreSQL listener: %w", err)
+	}
 	inviteAttemptLimiter := transportmw.RateLimitByAccountAndIP(cfg.App.InviteAttemptsPerMinute, time.Minute)
 	// 9. Khởi tạo Module Admin & Bank Directory Handler
 	adminRepo := adminpostgres.New(db)
@@ -246,7 +267,7 @@ func New(ctx context.Context) (*App, error) {
 	platformmetrics.RegisterDBPool(db)
 
 	// 10. Xây dựng Router và đăng ký tất cả các Endpoint API
-	appRouter := router.New(cfg.App, cfg.Metrics, db)
+	appRouter := router.New(cfg.App, cfg.Metrics, sharedListener)
 	liveAuth := transportmw.Auth(tokens, authRepo)
 	tokenAuth := transportmw.TokenAuth(tokens)
 	appRouter.Route("/api/v1", func(api chi.Router) {
@@ -265,21 +286,34 @@ func New(ctx context.Context) (*App, error) {
 	log.Println("[HTTP] API routes registered (/api/v1: auth, users, notifications, groups, bills, admin, banks)")
 
 	// 11. Khởi chạy River Queue Worker Engine
-	workerCtx, cancelWorkers := context.WithCancel(ctx)
+	workerCtx, cancelWorkers := context.WithCancel(context.Background())
+	listenerCtx, cancelListener := context.WithCancel(context.Background())
+	listenerDone := make(chan struct{})
+	go func() {
+		defer close(listenerDone)
+		if err := sharedListener.Run(listenerCtx); err != nil {
+			log.Printf("event=postgres_listener_stopped reason=%q", err.Error())
+		}
+	}()
 	if err := riverClient.Start(workerCtx); err != nil {
+		cancelListener()
+		<-listenerDone
 		cancelWorkers()
 		db.Close()
 		return nil, fmt.Errorf("start river client: %w", err)
 	}
-	log.Printf("[Queue] River queue worker engine started (%d workers)", cfg.River.WorkerCount)
+	log.Printf("[Queue] River queue worker engine started (workers=%d poll_only=%t fetch_poll_interval=%s)", cfg.River.WorkerCount, cfg.River.PollOnly, cfg.River.FetchPollInterval)
 
 	// 12. Khởi chạy tác vụ dọn dẹp định kỳ (Media Cleanup & Auth Cleanup)
 	cleanupWorkers := authjobs.New(authRepo, avatarStore, cfg.Cleanup.Interval, cfg.Cleanup.Retention, cfg.Cleanup.MediaWorkerInterval)
 
 	app := &App{
-		db:            db,
-		riverClient:   riverClient,
-		cancelWorkers: cancelWorkers,
+		db:             db,
+		riverClient:    riverClient,
+		closeSSE:       closeSSE,
+		cancelWorkers:  cancelWorkers,
+		cancelListener: cancelListener,
+		listenerDone:   listenerDone,
 		server: &http.Server{
 			Addr:    cfg.App.Address,
 			Handler: appRouter,
@@ -288,12 +322,6 @@ func New(ctx context.Context) (*App, error) {
 	app.workers.Add(1)
 	go func() { defer app.workers.Done(); cleanupWorkers.Run(workerCtx) }()
 	log.Printf("[Workers] Periodic cleanup workers started (interval: %v, media_interval: %v)", cfg.Cleanup.Interval, cfg.Cleanup.MediaWorkerInterval)
-
-	app.workers.Add(1)
-	go func() { defer app.workers.Done(); _ = billHub.StartPostgresListener(workerCtx) }()
-
-	app.workers.Add(1)
-	go func() { defer app.workers.Done(); _ = groupHub.StartPostgresListener(workerCtx) }()
 
 	app.workers.Add(1)
 	go func() {
@@ -325,16 +353,64 @@ func (a *App) Start() error {
 // Việc dừng River/workers/pool luôn chạy, kể cả khi HTTP server drain quá thời hạn ctx, để
 // không rò rỉ tài nguyên đúng vào lúc quá trình tắt orderly quan trọng nhất.
 func (a *App) Shutdown(ctx context.Context) error {
+	if a.closeSSE != nil {
+		a.closeSSE()
+	}
 	httpErr := a.server.Shutdown(ctx)
+	var riverErr error
 	if a.riverClient != nil {
-		_ = a.riverClient.Stop(ctx)
+		riverErr = a.riverClient.Stop(ctx)
 	}
-	a.cancelWorkers()
-	a.workers.Wait()
-	// Giữ pool hoạt động cho đến khi các handler đang xử lý request hoàn tất.
-	a.db.Close()
-	if httpErr != nil {
-		return fmt.Errorf("shutdown HTTP server: %w", httpErr)
+	if a.cancelListener != nil {
+		a.cancelListener()
 	}
-	return nil
+	var listenerErr error
+	if a.listenerDone != nil {
+		select {
+		case <-a.listenerDone:
+		case <-ctx.Done():
+			listenerErr = ctx.Err()
+		}
+	}
+	if a.cancelWorkers != nil {
+		a.cancelWorkers()
+	}
+	workersDone := make(chan struct{})
+	go func() {
+		a.workers.Wait()
+		close(workersDone)
+	}()
+	var workersErr error
+	select {
+	case <-workersDone:
+	case <-ctx.Done():
+		workersErr = ctx.Err()
+	}
+	poolDone := make(chan struct{})
+	go func() {
+		if a.db != nil {
+			a.db.Close()
+		}
+		close(poolDone)
+	}()
+	var poolErr error
+	select {
+	case <-poolDone:
+	case <-ctx.Done():
+		poolErr = ctx.Err()
+	}
+	return errors.Join(
+		wrapShutdownError("HTTP server", httpErr),
+		wrapShutdownError("River client", riverErr),
+		wrapShutdownError("PostgreSQL listener", listenerErr),
+		wrapShutdownError("workers", workersErr),
+		wrapShutdownError("database pool", poolErr),
+	)
+}
+
+func wrapShutdownError(component string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("shutdown %s: %w", component, err)
 }

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1,0 +1,72 @@
+package bootstrap
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestShutdownClosesSSEBeforeHTTPDrain(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		close(started)
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &http.Server{Handler: mux}
+	go func() { _ = server.Serve(listener) }()
+	defer func() { _ = server.Close() }()
+
+	go func() {
+		resp, err := http.Get("http://" + listener.Addr().String() + "/events")
+		if err != nil {
+			return
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSE handler did not start")
+	}
+
+	var order []string
+	listenerDone := make(chan struct{})
+	close(listenerDone)
+	app := &App{
+		server: server,
+		closeSSE: func() {
+			order = append(order, "sse")
+			close(release)
+		},
+		cancelListener: func() { order = append(order, "listener") },
+		cancelWorkers:  func() { order = append(order, "workers") },
+		listenerDone:   listenerDone,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := app.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if len(order) == 0 || order[0] != "sse" {
+		t.Fatalf("shutdown order = %v, want sse first", order)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,7 @@ type AppConfig struct {
 // đại diện cho một kết nối database đã được mở.
 type DatabaseConfig struct {
 	URL               string
+	ApplicationName   string
 	MaxConns          int32
 	MinConns          int32
 	MaxConnLifetime   time.Duration
@@ -110,8 +111,10 @@ type FirebaseConfig struct {
 
 // RiverConfig chứa cấu hình cho background job queue (River trên PostgreSQL).
 type RiverConfig struct {
-	WorkerCount   int
-	FetchCooldown time.Duration
+	WorkerCount       int
+	FetchCooldown     time.Duration
+	PollOnly          bool
+	FetchPollInterval time.Duration
 }
 
 // GroupConfig chứa cấu hình dùng riêng cho module group management.
@@ -278,6 +281,10 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	riverFetchPollInterval, err := durationEnv("RIVER_FETCH_POLL_INTERVAL_MS", 1000, time.Millisecond)
+	if err != nil {
+		return nil, err
+	}
 	ocrProviderTimeout, err := durationEnv("BILL_OCR_PROVIDER_TIMEOUT_SECONDS", 8, time.Second)
 	if err != nil {
 		return nil, err
@@ -395,6 +402,7 @@ func Load() (*Config, error) {
 		},
 		Database: DatabaseConfig{
 			URL:               os.Getenv("DATABASE_URL"),
+			ApplicationName:   stringEnv("DB_APPLICATION_NAME", "paysplit-api"),
 			MaxConns:          maxConns,
 			MinConns:          minConns,
 			MaxConnLifetime:   maxConnLifetime,
@@ -416,8 +424,13 @@ func Load() (*Config, error) {
 		Avatar:     AvatarConfig{UploadTimeout: avatarUploadTimeout, ProcessingTimeout: avatarProcessingTimeout, MaxConcurrentConversions: avatarConcurrency},
 		Cleanup:    CleanupConfig{Interval: cleanupInterval, Retention: retention, MediaWorkerInterval: mediaInterval, MediaMaxAttempts: mediaAttempts},
 		Firebase:   FirebaseConfig{CredentialsFile: os.Getenv("FIREBASE_CREDENTIALS_FILE"), CredentialsJSON: os.Getenv("FIREBASE_CREDENTIALS_JSON"), Timeout: fcmTimeout},
-		River:      RiverConfig{WorkerCount: riverWorkerCount, FetchCooldown: riverFetchCooldown},
-		Group:      GroupConfig{InviteBaseURL: os.Getenv("APP_INVITE_BASE_URL")},
+		River: RiverConfig{
+			WorkerCount:       riverWorkerCount,
+			FetchCooldown:     riverFetchCooldown,
+			PollOnly:          boolEnv("RIVER_POLL_ONLY", false),
+			FetchPollInterval: riverFetchPollInterval,
+		},
+		Group: GroupConfig{InviteBaseURL: os.Getenv("APP_INVITE_BASE_URL")},
 		OCR: OCRConfig{
 			APIKey:            os.Getenv("LLAMAINDEX_API_KEY"),
 			Endpoint:          stringEnv("LLAMAINDEX_EXTRACT_ENDPOINT", "https://api.cloud.llamaindex.ai"),
@@ -487,6 +500,9 @@ func (c *Config) Validate() error {
 	if strings.TrimSpace(c.Database.URL) == "" {
 		return errors.New("DATABASE_URL must not be empty")
 	}
+	if strings.TrimSpace(c.Database.ApplicationName) == "" {
+		return errors.New("DB_APPLICATION_NAME must not be empty")
+	}
 	if c.Database.MinConns < 0 || c.Database.MaxConns <= 0 || c.Database.MinConns > c.Database.MaxConns {
 		return errors.New("DB_MIN_CONNS must be non-negative and no greater than DB_MAX_CONNS")
 	}
@@ -520,8 +536,17 @@ func (c *Config) Validate() error {
 	if c.Cleanup.Interval <= 0 || c.Cleanup.Retention <= 0 || c.Cleanup.MediaWorkerInterval <= 0 || c.Cleanup.MediaMaxAttempts != 10 {
 		return errors.New("cleanup settings are invalid")
 	}
-	if c.River.WorkerCount <= 0 || c.River.FetchCooldown <= 0 {
-		return errors.New("river settings must be positive")
+	if c.River.WorkerCount <= 0 {
+		return errors.New("RIVER_WORKER_COUNT must be positive")
+	}
+	if c.River.FetchCooldown <= 0 {
+		return errors.New("RIVER_FETCH_COOLDOWN_MS must be positive")
+	}
+	if c.River.FetchPollInterval <= 0 {
+		return errors.New("RIVER_FETCH_POLL_INTERVAL_MS must be positive")
+	}
+	if c.River.FetchPollInterval < c.River.FetchCooldown {
+		return errors.New("RIVER_FETCH_POLL_INTERVAL_MS must be greater than or equal to RIVER_FETCH_COOLDOWN_MS")
 	}
 	if int32(c.River.WorkerCount) >= c.Database.MaxConns {
 		return errors.New("RIVER_WORKER_COUNT must be lower than DB_MAX_CONNS so the queue cannot starve the HTTP pool")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLoadAuthDefaults(t *testing.T) {
-	values := map[string]string{"HTTP_CORS_ALLOWED_ORIGINS": "http://localhost:3000", "DATABASE_URL": "postgres://local/test", "JWT_SECRET_KEY": "long-development-secret", "JWT_ACCESS_TOKEN_TTL_MINUTES": "15", "AUTH_REFRESH_TOKEN_TTL_HOURS": "168", "AUTH_EMAIL_VERIFICATION_TTL_MINUTES": "10", "AUTH_PASSWORD_RESET_TTL_MINUTES": "10", "AUTH_EMAIL_VERIFICATION_URL": "paysplit://verify-email", "AUTH_PASSWORD_RESET_URL": "paysplit://reset-password", "SMTP_USERNAME": "owner@gmail.com", "SMTP_APP_PASSWORD": "app-password", "CLOUDINARY_CLOUD_NAME": "test", "CLOUDINARY_API_KEY": "test", "CLOUDINARY_API_SECRET": "test", "APP_INVITE_BASE_URL": "https://paysplit.app/join"}
+	values := map[string]string{"HTTP_CORS_ALLOWED_ORIGINS": "http://localhost:3000", "DATABASE_URL": "postgres://local/test", "DB_APPLICATION_NAME": "paysplit-api", "JWT_SECRET_KEY": "long-development-secret", "JWT_ACCESS_TOKEN_TTL_MINUTES": "15", "AUTH_REFRESH_TOKEN_TTL_HOURS": "168", "AUTH_EMAIL_VERIFICATION_TTL_MINUTES": "10", "AUTH_PASSWORD_RESET_TTL_MINUTES": "10", "AUTH_EMAIL_VERIFICATION_URL": "paysplit://verify-email", "AUTH_PASSWORD_RESET_URL": "paysplit://reset-password", "SMTP_USERNAME": "owner@gmail.com", "SMTP_APP_PASSWORD": "app-password", "CLOUDINARY_CLOUD_NAME": "test", "CLOUDINARY_API_KEY": "test", "CLOUDINARY_API_SECRET": "test", "APP_INVITE_BASE_URL": "https://paysplit.app/join", "RIVER_FETCH_COOLDOWN_MS": "100", "RIVER_FETCH_POLL_INTERVAL_MS": "1000", "RIVER_POLL_ONLY": "false"}
 	for key, value := range values {
 		t.Setenv(key, value)
 	}
@@ -17,6 +17,12 @@ func TestLoadAuthDefaults(t *testing.T) {
 	}
 	if cfg.Auth.AccessTokenTTL != 15*time.Minute || cfg.Auth.RefreshTokenTTL != 7*24*time.Hour || cfg.Auth.EmailVerificationTTL != 10*time.Minute {
 		t.Fatalf("unexpected auth TTLs: %+v", cfg.Auth)
+	}
+	if cfg.Database.ApplicationName != "paysplit-api" {
+		t.Fatalf("DB application name = %q, want paysplit-api", cfg.Database.ApplicationName)
+	}
+	if cfg.River.PollOnly || cfg.River.FetchPollInterval != time.Second || cfg.River.FetchCooldown != 100*time.Millisecond {
+		t.Fatalf("unexpected River defaults: %+v", cfg.River)
 	}
 }
 
@@ -130,6 +136,46 @@ func TestValidateRejectsInvalidBillSSE(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsInvalidConnectionEfficientEventSettings(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*Config)
+		wantError string
+	}{
+		{
+			name:      "blank application name",
+			mutate:    func(cfg *Config) { cfg.Database.ApplicationName = " " },
+			wantError: "DB_APPLICATION_NAME",
+		},
+		{
+			name:      "non-positive fetch poll interval",
+			mutate:    func(cfg *Config) { cfg.River.FetchPollInterval = 0 },
+			wantError: "RIVER_FETCH_POLL_INTERVAL_MS",
+		},
+		{
+			name: "fetch poll interval below cooldown",
+			mutate: func(cfg *Config) {
+				cfg.River.FetchCooldown = time.Second
+				cfg.River.FetchPollInterval = 100 * time.Millisecond
+			},
+			wantError: "RIVER_FETCH_POLL_INTERVAL_MS",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			tt.mutate(cfg)
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Validate() error = %v, want %s", err, tt.wantError)
+			}
+			if tt.name == "fetch poll interval below cooldown" && !strings.Contains(err.Error(), "RIVER_FETCH_COOLDOWN_MS") {
+				t.Fatalf("Validate() error = %v, want RIVER_FETCH_COOLDOWN_MS", err)
+			}
+		})
+	}
+}
+
 func TestLoadSettlementDefaults_AC6AndAC10(t *testing.T) {
 	values := map[string]string{"HTTP_CORS_ALLOWED_ORIGINS": "http://localhost:3000", "DATABASE_URL": "postgres://local/test", "JWT_SECRET_KEY": "long-development-secret", "JWT_ACCESS_TOKEN_TTL_MINUTES": "15", "AUTH_REFRESH_TOKEN_TTL_HOURS": "168", "AUTH_EMAIL_VERIFICATION_TTL_MINUTES": "10", "AUTH_PASSWORD_RESET_TTL_MINUTES": "10", "AUTH_EMAIL_VERIFICATION_URL": "paysplit://verify-email", "AUTH_PASSWORD_RESET_URL": "paysplit://reset-password", "SMTP_USERNAME": "owner@gmail.com", "SMTP_APP_PASSWORD": "app-password", "CLOUDINARY_CLOUD_NAME": "test", "CLOUDINARY_API_KEY": "test", "CLOUDINARY_API_SECRET": "test", "APP_INVITE_BASE_URL": "https://paysplit.app/join"}
 	for key, value := range values {
@@ -173,13 +219,13 @@ func TestValidateRejectsEmptySettlementBaseURLByVariableName(t *testing.T) {
 func validConfig() *Config {
 	return &Config{
 		App:        AppConfig{Address: ":8080", RequestTimeout: 15 * time.Second, CORSAllowedOrigins: []string{"http://localhost"}, RateLimitRequestsPerMinute: 300, InviteAttemptsPerMinute: 30},
-		Database:   DatabaseConfig{URL: "postgres://local/test", MaxConns: 10, MinConns: 1, MaxConnLifetime: time.Hour, MaxConnIdleTime: time.Minute, HealthCheckPeriod: time.Second},
+		Database:   DatabaseConfig{URL: "postgres://local/test", ApplicationName: "paysplit-api", MaxConns: 10, MinConns: 1, MaxConnLifetime: time.Hour, MaxConnIdleTime: time.Minute, HealthCheckPeriod: time.Second},
 		Auth:       AuthConfig{JWTSecret: "secret", JWTIssuer: "issuer", AccessTokenTTL: 15 * time.Minute, RefreshTokenTTL: 7 * 24 * time.Hour, EmailVerificationTTL: 10 * time.Minute, PasswordResetTTL: 10 * time.Minute, EmailVerificationURL: "paysplit://verify", PasswordResetURL: "paysplit://reset"},
 		SMTP:       SMTPConfig{Host: "smtp.gmail.com", Port: 587, Username: "owner@gmail.com", AppPassword: "app", FromName: "PaySplit", Timeout: 5 * time.Second},
 		Cloudinary: CloudinaryConfig{CloudName: "test", APIKey: "test", APISecret: "test"},
 		Avatar:     AvatarConfig{UploadTimeout: 15 * time.Second, ProcessingTimeout: 10 * time.Second, MaxConcurrentConversions: 2},
 		Cleanup:    CleanupConfig{Interval: 24 * time.Hour, Retention: 30 * 24 * time.Hour, MediaWorkerInterval: time.Minute, MediaMaxAttempts: 10},
-		River:      RiverConfig{WorkerCount: 5, FetchCooldown: 100 * time.Millisecond},
+		River:      RiverConfig{WorkerCount: 5, FetchCooldown: 100 * time.Millisecond, FetchPollInterval: time.Second},
 		Group:      GroupConfig{InviteBaseURL: "https://paysplit.app/join"},
 		OCR:        OCRConfig{Endpoint: "https://api.cloud.llamaindex.ai", ProviderTimeout: 8 * time.Second, MaxAttempts: 3, RetryBaseDelay: time.Second, ManualLimit: 5, ManualWindowHours: 24 * time.Hour, RawRetentionDays: 30 * 24 * time.Hour},
 		BillImage:  BillImageConfig{MaxCount: 5, MaxBytes: 10 * 1024 * 1024, UploadTimeout: 15 * time.Second, ProcessingTimeout: 10 * time.Second, SignedURLTTL: 5 * time.Minute},

--- a/internal/modules/bill/delivery/http/sse_hub.go
+++ b/internal/modules/bill/delivery/http/sse_hub.go
@@ -3,12 +3,18 @@ package http
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	NotificationChannel = "bill_events"
+	subscriberBuffer    = 16
 )
 
 // Event đại diện cho một sự kiện realtime phát qua Server-Sent Events (SSE).
@@ -43,7 +49,7 @@ func NewHub(pool *pgxpool.Pool) *Hub {
 // Subscribe đăng ký lắng nghe sự kiện của một hóa đơn cụ thể.
 // Trả về channel nhận Event và hàm hủy đăng ký (cleanup).
 func (h *Hub) Subscribe(billID uuid.UUID) (chan Event, func()) {
-	ch := make(chan Event, 16)
+	ch := make(chan Event, subscriberBuffer)
 
 	h.mu.Lock()
 	if _, ok := h.subscribers[billID]; !ok {
@@ -56,12 +62,14 @@ func (h *Hub) Subscribe(billID uuid.UUID) (chan Event, func()) {
 		h.mu.Lock()
 		defer h.mu.Unlock()
 		if subs, ok := h.subscribers[billID]; ok {
-			delete(subs, ch)
-			if len(subs) == 0 {
-				delete(h.subscribers, billID)
+			if _, exists := subs[ch]; exists {
+				delete(subs, ch)
+				close(ch)
+				if len(subs) == 0 {
+					delete(h.subscribers, billID)
+				}
 			}
 		}
-		close(ch)
 	}
 
 	return ch, unsubscribe
@@ -104,7 +112,7 @@ func (h *Hub) Broadcast(billID uuid.UUID, eventType string, data any) {
 			if err != nil {
 				return
 			}
-			_, _ = h.pool.Exec(ctx, "SELECT pg_notify('bill_events', $1)", string(payloadBytes))
+			_, _ = h.pool.Exec(ctx, "SELECT pg_notify($1, $2)", NotificationChannel, string(payloadBytes))
 		}()
 	} else {
 		// Fallback cho môi trường không có PostgreSQL connection pool (ví dụ unit test)
@@ -112,56 +120,32 @@ func (h *Hub) Broadcast(billID uuid.UUID, eventType string, data any) {
 	}
 }
 
-// StartPostgresListener lắng nghe kênh pg_notify 'bill_events' từ các instance khác hoặc background worker.
-// Tự động thử kết nối lại khi gặp sự cố mạng hoặc database khởi động lại.
-func (h *Hub) StartPostgresListener(ctx context.Context) error {
-	if h.pool == nil {
-		return nil
+// HandlePostgresNotification giải mã và kiểm tra semantic envelope trước khi
+// phát tới subscriber cục bộ. Lỗi trả về không chứa raw payload.
+func (h *Hub) HandlePostgresNotification(_ context.Context, payload string) error {
+	var event Event
+	if err := json.Unmarshal([]byte(payload), &event); err != nil {
+		return errors.New("invalid_json")
 	}
-
-	for {
-		if ctx.Err() != nil {
-			return nil
-		}
-
-		err := h.listenLoop(ctx)
-		if err != nil {
-			if ctx.Err() != nil {
-				return nil
-			}
-			select {
-			case <-time.After(1 * time.Second):
-			case <-ctx.Done():
-				return nil
-			}
-		}
+	if event.BillID == uuid.Nil {
+		return errors.New("missing_bill_id")
 	}
+	if strings.TrimSpace(event.Type) == "" {
+		return errors.New("missing_type")
+	}
+	h.Publish(event)
+	return nil
 }
 
-func (h *Hub) listenLoop(ctx context.Context) error {
-	conn, err := h.pool.Acquire(ctx)
-	if err != nil {
-		return fmt.Errorf("acquire conn for pg_notify listener: %w", err)
-	}
-	defer conn.Release()
-
-	_, err = conn.Exec(ctx, "LISTEN bill_events")
-	if err != nil {
-		return fmt.Errorf("listen bill_events: %w", err)
-	}
-
-	for {
-		notification, err := conn.Conn().WaitForNotification(ctx)
-		if err != nil {
-			if ctx.Err() != nil {
-				return nil
-			}
-			return fmt.Errorf("wait for pg notification: %w", err)
+// CloseSubscribers đóng mọi stream cục bộ để client reconnect và lấy snapshot
+// sau khi PostgreSQL listener bị gián đoạn.
+func (h *Hub) CloseSubscribers() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for billID, subscribers := range h.subscribers {
+		for ch := range subscribers {
+			close(ch)
 		}
-
-		var event Event
-		if err := json.Unmarshal([]byte(notification.Payload), &event); err == nil {
-			h.Publish(event)
-		}
+		delete(h.subscribers, billID)
 	}
 }

--- a/internal/modules/bill/delivery/http/sse_hub_test.go
+++ b/internal/modules/bill/delivery/http/sse_hub_test.go
@@ -1,6 +1,8 @@
 package http_test
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,5 +53,80 @@ func TestSSEHub_Unsubscribe(t *testing.T) {
 		}
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("timed out waiting for channel close")
+	}
+}
+
+func TestSSEHub_HandlePostgresNotificationValidatesEnvelope(t *testing.T) {
+	hub := billhttp.NewHub(nil)
+	billID := uuid.New()
+	ch, unsubscribe := hub.Subscribe(billID)
+	defer unsubscribe()
+
+	payload := `{"type":"ocr.updated","bill_id":"` + billID.String() + `","data":{"status":"done"}}`
+	if err := hub.HandlePostgresNotification(context.Background(), payload); err != nil {
+		t.Fatalf("valid payload rejected: %v", err)
+	}
+	if event := <-ch; event.BillID != billID || event.Type != "ocr.updated" {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+
+	for _, invalid := range []string{
+		`not-json`,
+		`{"type":"ocr.updated","bill_id":"00000000-0000-0000-0000-000000000000"}`,
+		`{"type":" ","bill_id":"` + billID.String() + `"}`,
+	} {
+		if err := hub.HandlePostgresNotification(context.Background(), invalid); err == nil {
+			t.Fatalf("invalid payload accepted: %s", invalid)
+		}
+	}
+}
+
+func TestSSEHub_CloseSubscribersIsSafeWithDeferredUnsubscribe(t *testing.T) {
+	hub := billhttp.NewHub(nil)
+	ch, unsubscribe := hub.Subscribe(uuid.New())
+	hub.CloseSubscribers()
+	unsubscribe()
+	unsubscribe()
+	if _, open := <-ch; open {
+		t.Fatal("subscriber channel should be closed")
+	}
+}
+
+func TestSSEHub_SubscriberBufferIs16(t *testing.T) {
+	// covers: AC-2
+	const billSubscriberBuffer = 16
+	hub := billhttp.NewHub(nil)
+	billID := uuid.New()
+	ch, unsubscribe := hub.Subscribe(billID)
+	defer unsubscribe()
+
+	for i := 0; i < billSubscriberBuffer+8; i++ {
+		hub.Publish(billhttp.Event{Type: "ocr.updated", BillID: billID})
+	}
+
+	got := 0
+	for {
+		select {
+		case <-ch:
+			got++
+		default:
+			if got != billSubscriberBuffer {
+				t.Fatalf("buffered events = %d, want %d", got, billSubscriberBuffer)
+			}
+			return
+		}
+	}
+}
+
+func TestSSEHub_HandlePostgresNotificationErrorOmitsRawPayload(t *testing.T) {
+	// covers: AC-4
+	hub := billhttp.NewHub(nil)
+	const raw = "SECRET_RAW_BILL_PAYLOAD"
+	err := hub.HandlePostgresNotification(context.Background(), raw)
+	if err == nil {
+		t.Fatal("invalid payload accepted")
+	}
+	if strings.Contains(err.Error(), raw) {
+		t.Fatalf("error leaked raw payload: %v", err)
 	}
 }

--- a/internal/modules/group/delivery/http/sse_hub.go
+++ b/internal/modules/group/delivery/http/sse_hub.go
@@ -3,17 +3,16 @@ package http
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
+	"strings"
 	"sync"
-	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // notifyChannel là kênh pg_notify mà tầng repository phát sự kiện nhóm vào,
 // ngay bên trong transaction của mutation.
-const notifyChannel = "group_events"
+const NotificationChannel = "group_events"
 
 // subscriberBuffer là độ sâu hàng đợi cho mỗi kết nối SSE. Client chậm hơn mức
 // này sẽ bị bỏ sự kiện — đúng thiết kế: version fencing khiến client tự phát
@@ -45,13 +44,11 @@ type Broadcaster interface {
 type Hub struct {
 	mu          sync.RWMutex
 	subscribers map[uuid.UUID]map[chan Event]struct{}
-	pool        *pgxpool.Pool
 }
 
-func NewHub(pool *pgxpool.Pool) *Hub {
+func NewHub() *Hub {
 	return &Hub{
 		subscribers: make(map[uuid.UUID]map[chan Event]struct{}),
-		pool:        pool,
 	}
 }
 
@@ -66,19 +63,18 @@ func (h *Hub) Subscribe(groupID uuid.UUID) (chan Event, func()) {
 	h.subscribers[groupID][ch] = struct{}{}
 	h.mu.Unlock()
 
-	var once sync.Once
 	return ch, func() {
-		once.Do(func() {
-			h.mu.Lock()
-			defer h.mu.Unlock()
-			if subs, ok := h.subscribers[groupID]; ok {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if subs, ok := h.subscribers[groupID]; ok {
+			if _, exists := subs[ch]; exists {
 				delete(subs, ch)
+				close(ch)
 				if len(subs) == 0 {
 					delete(h.subscribers, groupID)
 				}
 			}
-			close(ch)
-		})
+		}
 	}
 }
 
@@ -97,53 +93,31 @@ func (h *Hub) Publish(event Event) {
 	}
 }
 
-// StartPostgresListener lắng nghe kênh pg_notify và tự kết nối lại khi mạng
-// hoặc database gặp sự cố.
-func (h *Hub) StartPostgresListener(ctx context.Context) error {
-	if h.pool == nil {
-		return nil
+func (h *Hub) HandlePostgresNotification(_ context.Context, payload string) error {
+	var event Event
+	if err := json.Unmarshal([]byte(payload), &event); err != nil {
+		return errors.New("invalid_json")
 	}
-
-	for {
-		if ctx.Err() != nil {
-			return nil
-		}
-		if err := h.listenLoop(ctx); err != nil {
-			if ctx.Err() != nil {
-				return nil
-			}
-			select {
-			case <-time.After(1 * time.Second):
-			case <-ctx.Done():
-				return nil
-			}
-		}
+	if event.GroupID == uuid.Nil {
+		return errors.New("missing_group_id")
 	}
+	if event.Version <= 0 {
+		return errors.New("invalid_version")
+	}
+	if strings.TrimSpace(event.Type) == "" {
+		return errors.New("missing_type")
+	}
+	h.Publish(event)
+	return nil
 }
 
-func (h *Hub) listenLoop(ctx context.Context) error {
-	conn, err := h.pool.Acquire(ctx)
-	if err != nil {
-		return fmt.Errorf("acquire conn for group event listener: %w", err)
-	}
-	defer conn.Release()
-
-	if _, err = conn.Exec(ctx, "LISTEN "+notifyChannel); err != nil {
-		return fmt.Errorf("listen %s: %w", notifyChannel, err)
-	}
-
-	for {
-		notification, err := conn.Conn().WaitForNotification(ctx)
-		if err != nil {
-			if ctx.Err() != nil {
-				return nil
-			}
-			return fmt.Errorf("wait for group notification: %w", err)
+func (h *Hub) CloseSubscribers() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for groupID, subscribers := range h.subscribers {
+		for ch := range subscribers {
+			close(ch)
 		}
-
-		var event Event
-		if err := json.Unmarshal([]byte(notification.Payload), &event); err == nil {
-			h.Publish(event)
-		}
+		delete(h.subscribers, groupID)
 	}
 }

--- a/internal/modules/group/delivery/http/sse_hub_test.go
+++ b/internal/modules/group/delivery/http/sse_hub_test.go
@@ -1,7 +1,9 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,7 +11,7 @@ import (
 )
 
 func TestHub_PublishReachesOnlySubscribersOfThatGroup(t *testing.T) {
-	hub := NewHub(nil)
+	hub := NewHub()
 	groupA, groupB := uuid.New(), uuid.New()
 
 	chA, unsubA := hub.Subscribe(groupA)
@@ -36,7 +38,7 @@ func TestHub_PublishReachesOnlySubscribersOfThatGroup(t *testing.T) {
 }
 
 func TestHub_UnsubscribeStopsDeliveryAndIsIdempotent(t *testing.T) {
-	hub := NewHub(nil)
+	hub := NewHub()
 	groupID := uuid.New()
 
 	ch, unsubscribe := hub.Subscribe(groupID)
@@ -55,7 +57,7 @@ func TestHub_UnsubscribeStopsDeliveryAndIsIdempotent(t *testing.T) {
 // Client chậm không được phép chặn server. Sự kiện bị bỏ là chấp nhận được vì
 // version fencing khiến client tự phát hiện lỗ hổng và gọi /sync.
 func TestHub_PublishDoesNotBlockOnFullSubscriberBuffer(t *testing.T) {
-	hub := NewHub(nil)
+	hub := NewHub()
 	groupID := uuid.New()
 
 	_, unsubscribe := hub.Subscribe(groupID)
@@ -97,5 +99,80 @@ func TestEvent_DecodesNotifyEnvelope(t *testing.T) {
 	}
 	if thin.Version != 43 || len(thin.Data) != 0 {
 		t.Fatalf("thin envelope should decode with no data: %+v", thin)
+	}
+}
+
+func TestHub_HandlePostgresNotificationValidatesEnvelope(t *testing.T) {
+	hub := NewHub()
+	groupID := uuid.New()
+	ch, unsubscribe := hub.Subscribe(groupID)
+	defer unsubscribe()
+
+	payload := `{"group_id":"` + groupID.String() + `","version":4,"type":"member_joined"}`
+	if err := hub.HandlePostgresNotification(context.Background(), payload); err != nil {
+		t.Fatalf("valid payload rejected: %v", err)
+	}
+	if event := <-ch; event.GroupID != groupID || event.Version != 4 {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+
+	for _, invalid := range []string{
+		`not-json`,
+		`{"group_id":"00000000-0000-0000-0000-000000000000","version":1,"type":"member_joined"}`,
+		`{"group_id":"` + groupID.String() + `","version":0,"type":"member_joined"}`,
+		`{"group_id":"` + groupID.String() + `","version":1,"type":" "}`,
+	} {
+		if err := hub.HandlePostgresNotification(context.Background(), invalid); err == nil {
+			t.Fatalf("invalid payload accepted: %s", invalid)
+		}
+	}
+}
+
+func TestHub_CloseSubscribersIsSafeWithDeferredUnsubscribe(t *testing.T) {
+	hub := NewHub()
+	ch, unsubscribe := hub.Subscribe(uuid.New())
+	hub.CloseSubscribers()
+	unsubscribe()
+	unsubscribe()
+	if _, open := <-ch; open {
+		t.Fatal("subscriber channel should be closed")
+	}
+}
+
+func TestHub_SubscriberBufferIs32(t *testing.T) {
+	// covers: AC-2
+	hub := NewHub()
+	groupID := uuid.New()
+	ch, unsubscribe := hub.Subscribe(groupID)
+	defer unsubscribe()
+
+	for i := 0; i < subscriberBuffer+8; i++ {
+		hub.Publish(Event{GroupID: groupID, Version: int64(i + 1), Type: "member_joined"})
+	}
+
+	got := 0
+	for {
+		select {
+		case <-ch:
+			got++
+		default:
+			if got != subscriberBuffer {
+				t.Fatalf("buffered events = %d, want %d", got, subscriberBuffer)
+			}
+			return
+		}
+	}
+}
+
+func TestHub_HandlePostgresNotificationErrorOmitsRawPayload(t *testing.T) {
+	// covers: AC-4
+	hub := NewHub()
+	const raw = "SECRET_RAW_GROUP_PAYLOAD"
+	err := hub.HandlePostgresNotification(context.Background(), raw)
+	if err == nil {
+		t.Fatal("invalid payload accepted")
+	}
+	if strings.Contains(err.Error(), raw) {
+		t.Fatalf("error leaked raw payload: %v", err)
 	}
 }

--- a/internal/platform/auth/jwt/access_token_manager.go
+++ b/internal/platform/auth/jwt/access_token_manager.go
@@ -51,7 +51,7 @@ func NewAccessTokenManager(secret, issuer string, ttl time.Duration) (*AccessTok
 }
 
 // Issue phát hành access token có role mặc định là user và trả về token cùng
-// thời gian hiệu lực tính bằng giây. Dùng IssueWithRole khi cần chỉ định role.
+// thời gian hiệu lực tính bằng giây.
 // Issue phát hành access token chứa ID người dùng, role và ID phiên đăng nhập.
 func (i *AccessTokenManager) Issue(userID, role, sessionID string) (string, time.Time, error) {
 	if strings.TrimSpace(userID) == "" {

--- a/internal/platform/banks/directory.go
+++ b/internal/platform/banks/directory.go
@@ -40,6 +40,8 @@ func Load() (*Directory, error) {
 	return parse(snapshot)
 }
 
+// parse phân tích snapshot danh mục ngân hàng.
+// Nó được gọi duy nhất một lần tại thời điểm build-time thông qua biến toàn cục snapshot.
 func parse(raw []byte) (*Directory, error) {
 	var data payload
 	if err := json.Unmarshal(raw, &data); err != nil {

--- a/internal/platform/database/notification_listener.go
+++ b/internal/platform/database/notification_listener.go
@@ -1,0 +1,233 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	platformmetrics "paysplit-backend/internal/platform/metrics"
+)
+
+const (
+	listenerBackoffBase  = 500 * time.Millisecond
+	listenerBackoffMax   = 30 * time.Second
+	listenerHealthyReset = 30 * time.Second
+	listenerCleanupLimit = 3 * time.Second
+)
+
+// NotificationHandler giải mã và phát một payload của channel tương ứng.
+// Handler phải hoàn tất nhanh vì listener dispatch đồng bộ để giữ thứ tự nhận.
+type NotificationHandler func(context.Context, string) error
+
+type notificationSession interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	WaitForNotification(context.Context) (*pgconn.Notification, error)
+	Release()
+	Destroy(context.Context) error
+}
+
+type poolNotificationSession struct {
+	conn *pgxpool.Conn
+}
+
+func (s *poolNotificationSession) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	return s.conn.Exec(ctx, sql, args...)
+}
+
+func (s *poolNotificationSession) WaitForNotification(ctx context.Context) (*pgconn.Notification, error) {
+	return s.conn.Conn().WaitForNotification(ctx)
+}
+
+func (s *poolNotificationSession) Release() {
+	s.conn.Release()
+}
+
+func (s *poolNotificationSession) Destroy(ctx context.Context) error {
+	return s.conn.Hijack().Close(ctx)
+}
+
+// PostgresNotificationListener sở hữu đúng một PostgreSQL session và đăng ký
+// tất cả channel trước khi chuyển sang trạng thái connected.
+type PostgresNotificationListener struct {
+	pool         *pgxpool.Pool
+	handlers     map[string]NotificationHandler
+	channels     []string
+	onDisconnect func()
+	acquire      func(context.Context) (notificationSession, error)
+
+	connected atomic.Bool
+	ready     chan struct{}
+	readyOnce sync.Once
+}
+
+func NewPostgresNotificationListener(
+	pool *pgxpool.Pool,
+	handlers map[string]NotificationHandler,
+	onDisconnect func(),
+) (*PostgresNotificationListener, error) {
+	if pool == nil {
+		return nil, errors.New("notification listener pool must not be nil")
+	}
+	if len(handlers) == 0 {
+		return nil, errors.New("notification listener handlers must not be empty")
+	}
+
+	listener := &PostgresNotificationListener{
+		pool:         pool,
+		handlers:     make(map[string]NotificationHandler, len(handlers)),
+		channels:     make([]string, 0, len(handlers)),
+		onDisconnect: onDisconnect,
+		ready:        make(chan struct{}),
+	}
+	for channel, handler := range handlers {
+		if channel == "" || handler == nil {
+			return nil, errors.New("notification listener channel and handler must not be empty")
+		}
+		listener.handlers[channel] = handler
+		listener.channels = append(listener.channels, channel)
+	}
+	sort.Strings(listener.channels)
+	listener.acquire = func(ctx context.Context) (notificationSession, error) {
+		conn, err := pool.Acquire(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return &poolNotificationSession{conn: conn}, nil
+	}
+	return listener, nil
+}
+
+// Ready đóng sau lần đầu listener đăng ký thành công mọi channel.
+func (l *PostgresNotificationListener) Ready() <-chan struct{} {
+	return l.ready
+}
+
+// Ping kiểm tra cả trạng thái listener và khả năng truy cập database để dùng
+// trực tiếp cho readiness probe.
+func (l *PostgresNotificationListener) Ping(ctx context.Context) error {
+	if l == nil || !l.connected.Load() {
+		return errors.New("PostgreSQL notification listener is disconnected")
+	}
+	return l.pool.Ping(ctx)
+}
+
+// Run duy trì listener cho đến khi context bị hủy. Mỗi lần reconnect dùng một
+// session mới và đăng ký lại toàn bộ channel.
+func (l *PostgresNotificationListener) Run(ctx context.Context) error {
+	attempt := 0
+	for {
+		connectedAt, reason, channel, err := l.runSession(ctx)
+		if ctx.Err() != nil {
+			l.setConnected(false)
+			return nil
+		}
+		if err == nil {
+			return nil
+		}
+
+		l.setConnected(false)
+		if !connectedAt.IsZero() {
+			if l.onDisconnect != nil {
+				l.onDisconnect()
+			}
+			if time.Since(connectedAt) >= listenerHealthyReset {
+				attempt = 0
+			}
+		}
+
+		platformmetrics.RecordDBListenerReconnect(reason)
+		backoff := listenerBackoff(attempt)
+		log.Printf("event=postgres_listener_reconnect channel=%s reason=%s attempt=%d backoff=%s", channel, reason, attempt, backoff)
+		attempt++
+
+		timer := time.NewTimer(backoff)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return nil
+		}
+	}
+}
+
+func (l *PostgresNotificationListener) runSession(ctx context.Context) (time.Time, string, string, error) {
+	session, err := l.acquire(ctx)
+	if err != nil {
+		return time.Time{}, "acquire", "all", fmt.Errorf("acquire notification listener connection: %w", err)
+	}
+	cleanRelease := false
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), listenerCleanupLimit)
+		defer cancel()
+		if cleanRelease {
+			if _, cleanupErr := session.Exec(cleanupCtx, "UNLISTEN *"); cleanupErr == nil {
+				session.Release()
+				return
+			}
+		}
+		_ = session.Destroy(cleanupCtx)
+	}()
+
+	for _, channel := range l.channels {
+		if _, err = session.Exec(ctx, "LISTEN "+pgx.Identifier{channel}.Sanitize()); err != nil {
+			return time.Time{}, "listen", channel, fmt.Errorf("listen %s: %w", channel, err)
+		}
+	}
+
+	connectedAt := time.Now()
+	l.setConnected(true)
+	l.readyOnce.Do(func() { close(l.ready) })
+
+	for {
+		notification, waitErr := session.WaitForNotification(ctx)
+		if waitErr != nil {
+			l.setConnected(false)
+			if ctx.Err() != nil {
+				cleanRelease = true
+				return connectedAt, "", "all", ctx.Err()
+			}
+			return connectedAt, "wait", "all", fmt.Errorf("wait for PostgreSQL notification: %w", waitErr)
+		}
+
+		handler, ok := l.handlers[notification.Channel]
+		if !ok {
+			continue
+		}
+		if handlerErr := handler(ctx, notification.Payload); handlerErr != nil {
+			platformmetrics.RecordDBListenerInvalidPayload(notification.Channel)
+			log.Printf("event=postgres_listener_invalid_payload channel=%s reason=%q", notification.Channel, handlerErr.Error())
+		}
+	}
+}
+
+func (l *PostgresNotificationListener) setConnected(connected bool) {
+	l.connected.Store(connected)
+	platformmetrics.SetDBListenerConnected(connected)
+}
+
+func listenerBackoff(attempt int) time.Duration {
+	base := listenerBackoffBase
+	for i := 0; i < attempt && base < listenerBackoffMax; i++ {
+		if base > listenerBackoffMax/2 {
+			base = listenerBackoffMax
+			break
+		}
+		base *= 2
+	}
+	factor := 0.8 + rand.Float64()*0.4
+	delay := time.Duration(float64(base) * factor)
+	if delay > listenerBackoffMax {
+		return listenerBackoffMax
+	}
+	return delay
+}

--- a/internal/platform/database/notification_listener_integration_test.go
+++ b/internal/platform/database/notification_listener_integration_test.go
@@ -1,0 +1,104 @@
+package database_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"paysplit-backend/internal/platform/database"
+)
+
+func TestPostgresNotificationListener_IntegrationListensOnBothChannels(t *testing.T) {
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	poolConfig, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		t.Fatalf("parse pool config: %v", err)
+	}
+	poolConfig.ConnConfig.RuntimeParams["application_name"] = "paysplit-listener-integration"
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	defer pool.Close()
+
+	received := make(chan string, 2)
+	listener, err := database.NewPostgresNotificationListener(pool, map[string]database.NotificationHandler{
+		"bill_events": func(_ context.Context, payload string) error {
+			received <- "bill:" + payload
+			return nil
+		},
+		"group_events": func(_ context.Context, payload string) error {
+			received <- "group:" + payload
+			return nil
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listenerCtx, stopListener := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() { done <- listener.Run(listenerCtx) }()
+	select {
+	case <-listener.Ready():
+	case <-ctx.Done():
+		t.Fatal("listener did not become ready")
+	}
+	var listenerSessions int
+	if err = pool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM pg_stat_activity
+		WHERE application_name = 'paysplit-listener-integration'
+		  AND state = 'idle'
+		  AND query LIKE 'LISTEN %'
+	`).Scan(&listenerSessions); err != nil {
+		t.Fatalf("count listener sessions: %v", err)
+	}
+	if listenerSessions != 1 {
+		t.Fatalf("LISTEN sessions = %d, want exactly 1", listenerSessions)
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin notify transaction: %v", err)
+	}
+	if _, err = tx.Exec(ctx, "SELECT pg_notify($1, $2)", "bill_events", "one"); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("notify bill channel: %v", err)
+	}
+	if _, err = tx.Exec(ctx, "SELECT pg_notify($1, $2)", "group_events", "two"); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("notify group channel: %v", err)
+	}
+	if err = tx.Commit(ctx); err != nil {
+		t.Fatalf("commit notifications: %v", err)
+	}
+
+	for _, want := range []string{"bill:one", "group:two"} {
+		select {
+		case got := <-received:
+			if got != want {
+				t.Fatalf("received %q, want %q", got, want)
+			}
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for %q", want)
+		}
+	}
+
+	stopListener()
+	if err := <-done; err != nil {
+		t.Fatalf("listener shutdown: %v", err)
+	}
+	if acquired := pool.Stat().AcquiredConns(); acquired != 0 {
+		t.Fatalf("acquired connections after listener shutdown = %d, want 0", acquired)
+	}
+}

--- a/internal/platform/database/notification_listener_test.go
+++ b/internal/platform/database/notification_listener_test.go
@@ -1,0 +1,343 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type fakeNotificationSession struct {
+	mu            sync.Mutex
+	execCalls     []string
+	failExecAt    int
+	waitErr       error
+	notifications chan *pgconn.Notification
+	released      bool
+	destroyed     bool
+}
+
+func newFakeNotificationSession() *fakeNotificationSession {
+	return &fakeNotificationSession{notifications: make(chan *pgconn.Notification, 4)}
+}
+
+func (s *fakeNotificationSession) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.execCalls = append(s.execCalls, sql)
+	if s.failExecAt > 0 && len(s.execCalls) == s.failExecAt {
+		return pgconn.CommandTag{}, errors.New("forced exec failure")
+	}
+	return pgconn.NewCommandTag("LISTEN"), nil
+}
+
+func (s *fakeNotificationSession) WaitForNotification(ctx context.Context) (*pgconn.Notification, error) {
+	s.mu.Lock()
+	if s.waitErr != nil {
+		err := s.waitErr
+		s.waitErr = nil
+		s.mu.Unlock()
+		return nil, err
+	}
+	s.mu.Unlock()
+	select {
+	case notification := <-s.notifications:
+		return notification, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (s *fakeNotificationSession) Release() {
+	s.mu.Lock()
+	s.released = true
+	s.mu.Unlock()
+}
+
+func (s *fakeNotificationSession) Destroy(context.Context) error {
+	s.mu.Lock()
+	s.destroyed = true
+	s.mu.Unlock()
+	return nil
+}
+
+func testListener(session notificationSession, handlers map[string]NotificationHandler) *PostgresNotificationListener {
+	listener := &PostgresNotificationListener{
+		handlers: handlers,
+		channels: []string{"bill_events", "group_events"},
+		ready:    make(chan struct{}),
+	}
+	listener.acquire = func(context.Context) (notificationSession, error) { return session, nil }
+	return listener
+}
+
+func TestPostgresNotificationListener_RoutesBothChannelsAndCleansSession(t *testing.T) {
+	session := newFakeNotificationSession()
+	received := make(chan string, 2)
+	listener := testListener(session, map[string]NotificationHandler{
+		"bill_events": func(_ context.Context, payload string) error {
+			received <- "bill:" + payload
+			return nil
+		},
+		"group_events": func(_ context.Context, payload string) error {
+			received <- "group:" + payload
+			return nil
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- listener.Run(ctx) }()
+	select {
+	case <-listener.Ready():
+	case <-time.After(time.Second):
+		t.Fatal("listener did not become ready")
+	}
+
+	session.notifications <- &pgconn.Notification{Channel: "bill_events", Payload: "one"}
+	session.notifications <- &pgconn.Notification{Channel: "group_events", Payload: "two"}
+	for _, want := range []string{"bill:one", "group:two"} {
+		select {
+		case got := <-received:
+			if got != want {
+				t.Fatalf("routed payload = %q, want %q", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for %q", want)
+		}
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	if len(session.execCalls) != 3 || session.execCalls[2] != "UNLISTEN *" {
+		t.Fatalf("exec calls = %v, want two LISTEN calls then UNLISTEN *", session.execCalls)
+	}
+	if !session.released || session.destroyed {
+		t.Fatalf("clean session released=%t destroyed=%t", session.released, session.destroyed)
+	}
+}
+
+func TestPostgresNotificationListener_PartialListenDestroysSession(t *testing.T) {
+	session := newFakeNotificationSession()
+	session.failExecAt = 2
+	listener := testListener(session, map[string]NotificationHandler{
+		"bill_events":  func(context.Context, string) error { return nil },
+		"group_events": func(context.Context, string) error { return nil },
+	})
+
+	_, reason, channel, err := listener.runSession(context.Background())
+	if err == nil || reason != "listen" || channel != "group_events" {
+		t.Fatalf("runSession() = reason %q channel %q err %v", reason, channel, err)
+	}
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	if session.released || !session.destroyed {
+		t.Fatalf("dirty session released=%t destroyed=%t", session.released, session.destroyed)
+	}
+}
+
+func TestListenerBackoffStaysWithinConfiguredBounds(t *testing.T) {
+	for attempt := 0; attempt < 20; attempt++ {
+		delay := listenerBackoff(attempt)
+		if delay < 400*time.Millisecond || delay > listenerBackoffMax {
+			t.Fatalf("listenerBackoff(%d) = %s, outside configured bounds", attempt, delay)
+		}
+	}
+}
+
+func TestPostgresNotificationListener_ReconnectsAndClosesSubscribersAfterWaitFailure(t *testing.T) {
+	first := newFakeNotificationSession()
+	first.waitErr = errors.New("connection reset")
+	second := newFakeNotificationSession()
+	listener := testListener(first, map[string]NotificationHandler{
+		"bill_events":  func(context.Context, string) error { return nil },
+		"group_events": func(context.Context, string) error { return nil },
+	})
+	acquiredSecond := make(chan struct{})
+	acquires := 0
+	listener.acquire = func(context.Context) (notificationSession, error) {
+		acquires++
+		if acquires == 1 {
+			return first, nil
+		}
+		select {
+		case <-acquiredSecond:
+		default:
+			close(acquiredSecond)
+		}
+		return second, nil
+	}
+	disconnected := make(chan struct{}, 1)
+	listener.onDisconnect = func() { disconnected <- struct{}{} }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- listener.Run(ctx) }()
+	select {
+	case <-acquiredSecond:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener did not reconnect")
+	}
+	select {
+	case <-disconnected:
+	default:
+		t.Fatal("disconnect callback was not called")
+	}
+
+	first.mu.Lock()
+	if !first.destroyed || first.released {
+		t.Fatalf("failed session released=%t destroyed=%t", first.released, first.destroyed)
+	}
+	first.mu.Unlock()
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	second.mu.Lock()
+	defer second.mu.Unlock()
+	if !second.released || second.destroyed {
+		t.Fatalf("replacement session released=%t destroyed=%t", second.released, second.destroyed)
+	}
+}
+
+func TestPostgresNotificationListener_ContextCancelSkipsOnDisconnect(t *testing.T) {
+	session := newFakeNotificationSession()
+	listener := testListener(session, map[string]NotificationHandler{
+		"bill_events":  func(context.Context, string) error { return nil },
+		"group_events": func(context.Context, string) error { return nil },
+	})
+	disconnected := 0
+	listener.onDisconnect = func() { disconnected++ }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- listener.Run(ctx) }()
+	select {
+	case <-listener.Ready():
+	case <-time.After(time.Second):
+		t.Fatal("listener did not become ready")
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if disconnected != 0 {
+		t.Fatalf("onDisconnect called %d times on clean cancel, want 0", disconnected)
+	}
+}
+
+func TestNewPostgresNotificationListener_RejectsEmptyRegistry(t *testing.T) {
+	// covers: AC-1
+	if _, err := NewPostgresNotificationListener(nil, map[string]NotificationHandler{
+		"bill_events": func(context.Context, string) error { return nil },
+	}, nil); err == nil {
+		t.Fatal("nil pool accepted")
+	}
+	if _, err := NewPostgresNotificationListener(&pgxpool.Pool{}, map[string]NotificationHandler{}, nil); err == nil {
+		t.Fatal("empty handlers accepted")
+	}
+	if _, err := NewPostgresNotificationListener(&pgxpool.Pool{}, map[string]NotificationHandler{
+		"": func(context.Context, string) error { return nil },
+	}, nil); err == nil {
+		t.Fatal("blank channel accepted")
+	}
+}
+
+func TestPostgresNotificationListener_PingReportsDisconnected(t *testing.T) {
+	// covers: AC-3
+	listener := testListener(newFakeNotificationSession(), map[string]NotificationHandler{
+		"bill_events":  func(context.Context, string) error { return nil },
+		"group_events": func(context.Context, string) error { return nil },
+	})
+	if err := listener.Ping(context.Background()); err == nil {
+		t.Fatal("disconnected listener reported healthy")
+	}
+}
+
+func TestPostgresNotificationListener_HandlerErrorKeepsSession(t *testing.T) {
+	// covers: AC-4
+	session := newFakeNotificationSession()
+	received := make(chan string, 1)
+	listener := testListener(session, map[string]NotificationHandler{
+		"bill_events": func(_ context.Context, payload string) error {
+			if payload == "bad" {
+				return errors.New("invalid_json")
+			}
+			received <- payload
+			return nil
+		},
+		"group_events": func(context.Context, string) error { return nil },
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- listener.Run(ctx) }()
+	select {
+	case <-listener.Ready():
+	case <-time.After(time.Second):
+		t.Fatal("listener did not become ready")
+	}
+
+	session.notifications <- &pgconn.Notification{Channel: "bill_events", Payload: "bad"}
+	session.notifications <- &pgconn.Notification{Channel: "bill_events", Payload: "good"}
+	select {
+	case got := <-received:
+		if got != "good" {
+			t.Fatalf("payload = %q, want good", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("valid payload after a handler error never arrived")
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	if !session.released || session.destroyed {
+		t.Fatalf("session after handler error released=%t destroyed=%t", session.released, session.destroyed)
+	}
+}
+
+func TestPostgresNotificationListener_UnlistenFailureDestroysSession(t *testing.T) {
+	// covers: AC-9
+	session := newFakeNotificationSession()
+	session.failExecAt = 3
+	listener := testListener(session, map[string]NotificationHandler{
+		"bill_events":  func(context.Context, string) error { return nil },
+		"group_events": func(context.Context, string) error { return nil },
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- listener.Run(ctx) }()
+	select {
+	case <-listener.Ready():
+	case <-time.After(time.Second):
+		t.Fatal("listener did not become ready")
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	if len(session.execCalls) < 3 || session.execCalls[2] != "UNLISTEN *" {
+		t.Fatalf("exec calls = %v, want UNLISTEN * after two LISTEN calls", session.execCalls)
+	}
+	if session.released || !session.destroyed {
+		t.Fatalf("failed UNLISTEN released=%t destroyed=%t", session.released, session.destroyed)
+	}
+}

--- a/internal/platform/database/postgres.go
+++ b/internal/platform/database/postgres.go
@@ -22,6 +22,7 @@ func ParsePoolConfig(cfg config.DatabaseConfig) (*pgxpool.Config, error) {
 	poolConfig.MaxConnLifetime = cfg.MaxConnLifetime
 	poolConfig.MaxConnIdleTime = cfg.MaxConnIdleTime
 	poolConfig.HealthCheckPeriod = cfg.HealthCheckPeriod
+	poolConfig.ConnConfig.RuntimeParams["application_name"] = cfg.ApplicationName
 	return poolConfig, nil
 }
 

--- a/internal/platform/database/postgres_test.go
+++ b/internal/platform/database/postgres_test.go
@@ -1,0 +1,27 @@
+package database
+
+import (
+	"testing"
+	"time"
+
+	"paysplit-backend/internal/config"
+)
+
+func TestParsePoolConfigSetsApplicationName(t *testing.T) {
+	// covers: AC-10
+	cfg, err := ParsePoolConfig(config.DatabaseConfig{
+		URL:               "postgres://postgres:postgres@localhost:5433/paysplit?sslmode=disable",
+		ApplicationName:   "paysplit-api-test",
+		MaxConns:          6,
+		MinConns:          0,
+		MaxConnLifetime:   time.Hour,
+		MaxConnIdleTime:   15 * time.Minute,
+		HealthCheckPeriod: 30 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.ConnConfig.RuntimeParams["application_name"]; got != "paysplit-api-test" {
+		t.Fatalf("application_name = %q, want paysplit-api-test", got)
+	}
+}

--- a/internal/platform/image/avatar/processor.go
+++ b/internal/platform/image/avatar/processor.go
@@ -26,16 +26,32 @@ type Processor struct {
 	slots   chan struct{}
 }
 
+// conversion là một struct helper để trả về kết quả từ goroutine.
+type conversion struct {
+	data []byte
+	err  error
+}
+
+// NewProcessor khởi tạo processor chuyển đổi ảnh avatar.
+// timeout: thời gian chờ tối đa cho mỗi lần convert, tính cả việc chờ slot rảnh.
+// maxConcurrent: số lượng ảnh có thể xử lý đồng thời (số slot).
+// Nếu timeout hoặc maxConcurrent ≤ 0, processor không thể khởi tạo và hàm sẽ panic.
 func NewProcessor(timeout time.Duration, maxConcurrent int) *Processor {
 	if timeout <= 0 || maxConcurrent <= 0 {
 		panic("avatar processor settings must be positive")
 	}
 	return &Processor{timeout: timeout, slots: make(chan struct{}, maxConcurrent)}
 }
+
+// IsUnsupported kiểm tra xem lỗi có phải là định dạng ảnh không được hỗ trợ hoặc do timeout hay không.
+// Nó trả về true nếu err là ErrUnsupportedFormat hoặc context.DeadlineExceeded.
 func (p *Processor) IsUnsupported(err error) bool {
 	return errors.Is(err, ErrUnsupportedFormat) || errors.Is(err, context.DeadlineExceeded)
 }
 
+// Convert chuyển đổi ảnh đầu vào thành định dạng WebP với các ràng buộc về kích thước và chất lượng.
+// input: dữ liệu ảnh dưới dạng byte slice.
+// Trả về dữ liệu ảnh đã chuyển đổi sang WebP hoặc lỗi nếu có vấn đề.
 func (p *Processor) Convert(ctx context.Context, input []byte) ([]byte, error) {
 	if len(input) == 0 || len(input) > 10<<20 {
 		return nil, ErrInvalidImage
@@ -49,32 +65,40 @@ func (p *Processor) Convert(ctx context.Context, input []byte) ([]byte, error) {
 	}
 	select {
 	case p.slots <- struct{}{}:
+		// Chiếm được 1 slot thành công -> Chạy tiếp xuống dưới!
 	case <-ctx.Done():
+		// Trong lúc đang đứng chờ slot mà client ngắt kết nối/tắt app -> Hủy, thoát ngay!
 		return nil, ctx.Err()
 	}
+	// Tạo channel để nhận kết quả từ goroutine
 	result := make(chan conversion, 1)
+	// Goroutine để xử lý convert
 	go func() {
-		defer func() { <-p.slots }()
+		defer func() { <-p.slots }() // Giải phóng slot sau khi xử lý xong
 		data, err := convert(input)
 		result <- conversion{data: data, err: err}
 	}()
+	// Tạo timer để giới hạn thời gian xử lý (bao gồm cả chờ slot)
 	timer := time.NewTimer(p.timeout)
+	// Đảm bảo timer được stop để không rò rỉ tài nguyên
 	defer timer.Stop()
+	// Chờ kết quả từ goroutine hoặc context timeout
 	select {
 	case out := <-result:
+		// Nhận kết quả convert từ goroutine
 		return out.data, out.err
 	case <-ctx.Done():
+		// Context bị cancel (client ngắt kết nối) hoặc timeout (không có kết quả trong thời gian p.timeout)
 		return nil, ctx.Err()
 	case <-timer.C:
+		// Thời gian chờ xử lý đã hết -> Timeout
 		return nil, context.DeadlineExceeded
 	}
 }
 
-type conversion struct {
-	data []byte
-	err  error
-}
-
+// convert thực hiện chuyển đổi thực tế từ ảnh đầu vào sang WebP.
+// Nó chỉ được gọi nội bộ bởi Convert và không tiếp xúc trực tiếp với các channel hoặc timeout.
+// Hàm này sẽ panic nếu gặp lỗi nghiêm trọng như image.Decode thất bại hoặc lỗi webp.Encode.
 func convert(input []byte) ([]byte, error) {
 	img, _, err := image.Decode(bytes.NewReader(input))
 	if err != nil {
@@ -98,6 +122,10 @@ func convert(input []byte) ([]byte, error) {
 	}
 	return output.Bytes(), nil
 }
+
+// orient xoay ảnh dựa trên thông tin EXIF Orientation.
+// Nếu không có EXIF hoặc lỗi đọc EXIF, trả về ảnh gốc.
+// Các giá trị Orientation được hỗ trợ: 2 (Flip Horizontal), 3 (Rotate 180), 4 (Flip Vertical), 5 (Transpose), 6 (Rotate 270), 7 (Transverse), 8 (Rotate 90).
 func orient(img image.Image, input []byte) image.Image {
 	metadata, err := exif.Decode(bytes.NewReader(input))
 	if err != nil {
@@ -130,9 +158,15 @@ func orient(img image.Image, input []byte) image.Image {
 		return img
 	}
 }
+
+// localType kiểm tra xem một Content-Type có phải là định dạng ảnh nội bộ được hỗ trợ hay không.
+// Các định dạng được hỗ trợ: image/jpeg, image/png, image/gif, image/webp.
 func localType(value string) bool {
 	return strings.HasPrefix(value, "image/jpeg") || strings.HasPrefix(value, "image/png") || strings.HasPrefix(value, "image/gif") || strings.HasPrefix(value, "image/webp")
 }
+
+// looksLikeHEIC kiểm tra xem dữ liệu byte có giống với định dạng HEIC hay không dựa trên magic number.
+// Lưu ý: Đây chỉ là kiểm tra heuristics đơn giản, không đảm bảo chính xác 100%.
 func looksLikeHEIC(data []byte) bool {
 	return len(data) >= 12 && string(data[4:8]) == "ftyp" && (strings.HasPrefix(string(data[8:12]), "hei") || strings.HasPrefix(string(data[8:12]), "mif1"))
 }

--- a/internal/platform/metrics/prometheus.go
+++ b/internal/platform/metrics/prometheus.go
@@ -83,6 +83,35 @@ var (
 		},
 	)
 
+	DBListenerConnected = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "paysplit",
+			Subsystem: "db",
+			Name:      "listener_connected",
+			Help:      "Whether the shared PostgreSQL notification listener is connected and subscribed to every channel.",
+		},
+	)
+
+	DBListenerReconnectsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "paysplit",
+			Subsystem: "db",
+			Name:      "listener_reconnects_total",
+			Help:      "Total shared PostgreSQL notification listener reconnects by bounded reason.",
+		},
+		[]string{"reason"},
+	)
+
+	DBListenerInvalidPayloadsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "paysplit",
+			Subsystem: "db",
+			Name:      "listener_invalid_payloads_total",
+			Help:      "Total invalid PostgreSQL notification payloads by bounded channel.",
+		},
+		[]string{"channel"},
+	)
+
 	// Domain Metrics Module 3: Bill & OCR v1 (Spec 3 index.md:187, AC-14)
 	OCRQueueDepth = prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -216,6 +245,9 @@ func init() {
 	prometheus.MustRegister(dbPoolAcquiredConns)
 	prometheus.MustRegister(dbPoolIdleConns)
 	prometheus.MustRegister(dbPoolTotalConns)
+	prometheus.MustRegister(DBListenerConnected)
+	prometheus.MustRegister(DBListenerReconnectsTotal)
+	prometheus.MustRegister(DBListenerInvalidPayloadsTotal)
 
 	// Register Module 3 Domain Metrics
 	prometheus.MustRegister(OCRQueueDepth)
@@ -300,6 +332,28 @@ func SetOCRQueueDepth(depth float64) {
 // RegisterDBPool đăng ký pool database để đo lường metrics kết nối.
 func RegisterDBPool(pool *pgxpool.Pool) {
 	activePool = pool
+}
+
+func SetDBListenerConnected(connected bool) {
+	if connected {
+		DBListenerConnected.Set(1)
+		return
+	}
+	DBListenerConnected.Set(0)
+}
+
+func RecordDBListenerReconnect(reason string) {
+	switch reason {
+	case "acquire", "listen", "wait":
+		DBListenerReconnectsTotal.WithLabelValues(reason).Inc()
+	}
+}
+
+func RecordDBListenerInvalidPayload(channel string) {
+	switch channel {
+	case "bill_events", "group_events":
+		DBListenerInvalidPayloadsTotal.WithLabelValues(channel).Inc()
+	}
 }
 
 // HTTPMetricsMiddleware ghi nhận counter và latency cho mỗi request.

--- a/internal/platform/metrics/prometheus_test.go
+++ b/internal/platform/metrics/prometheus_test.go
@@ -42,6 +42,34 @@ func TestSetOCRQueueDepth_SetsAbsoluteValue(t *testing.T) {
 	}
 }
 
+func TestDBListenerMetricsUseBoundedLabels(t *testing.T) {
+	metrics.SetDBListenerConnected(true)
+	if got := testutil.ToFloat64(metrics.DBListenerConnected); got != 1 {
+		t.Fatalf("listener connected gauge = %v, want 1", got)
+	}
+	metrics.SetDBListenerConnected(false)
+
+	reconnectBefore := testutil.ToFloat64(metrics.DBListenerReconnectsTotal.WithLabelValues("wait"))
+	metrics.RecordDBListenerReconnect("wait")
+	metrics.RecordDBListenerReconnect("unbounded-error-text")
+	if got := testutil.ToFloat64(metrics.DBListenerReconnectsTotal.WithLabelValues("wait")); got != reconnectBefore+1 {
+		t.Fatalf("listener reconnect counter = %v, want %v", got, reconnectBefore+1)
+	}
+	if got := testutil.ToFloat64(metrics.DBListenerReconnectsTotal.WithLabelValues("unbounded-error-text")); got != 0 {
+		t.Fatalf("unexpected unbounded reconnect label count %v", got)
+	}
+
+	payloadBefore := testutil.ToFloat64(metrics.DBListenerInvalidPayloadsTotal.WithLabelValues("bill_events"))
+	metrics.RecordDBListenerInvalidPayload("bill_events")
+	metrics.RecordDBListenerInvalidPayload("attacker-controlled-channel")
+	if got := testutil.ToFloat64(metrics.DBListenerInvalidPayloadsTotal.WithLabelValues("bill_events")); got != payloadBefore+1 {
+		t.Fatalf("invalid payload counter = %v, want %v", got, payloadBefore+1)
+	}
+	if got := testutil.ToFloat64(metrics.DBListenerInvalidPayloadsTotal.WithLabelValues("attacker-controlled-channel")); got != 0 {
+		t.Fatalf("unexpected unbounded channel label count %v", got)
+	}
+}
+
 func TestRecordOCRJob_IncrementsCounterWithStateAndErrorCodeLabels(t *testing.T) {
 	// covers: AC-14 (paysplit_ocr_jobs_total labeled by final application state and cleaned error code)
 	before := testutil.ToFloat64(metrics.OCRJobsTotal.WithLabelValues("succeeded_test_case_a", "none"))

--- a/internal/platform/queue/river/client.go
+++ b/internal/platform/queue/river/client.go
@@ -13,9 +13,11 @@ import (
 )
 
 type Config struct {
-	MaxWorkers    int
-	FetchCooldown time.Duration
-	PeriodicJobs  []*river.PeriodicJob
+	MaxWorkers        int
+	FetchCooldown     time.Duration
+	PollOnly          bool
+	FetchPollInterval time.Duration
+	PeriodicJobs      []*river.PeriodicJob
 }
 
 // AutoMigrate tự động chạy migration để tạo/cập nhật các bảng nội bộ của River trong PostgreSQL
@@ -45,6 +47,15 @@ func NewClient(dbPool *pgxpool.Pool, workers *river.Workers, cfg Config) (*river
 		return nil, fmt.Errorf("workers registry must not be nil")
 	}
 
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), clientConfig(workers, cfg))
+	if err != nil {
+		return nil, fmt.Errorf("create river client: %w", err)
+	}
+
+	return riverClient, nil
+}
+
+func clientConfig(workers *river.Workers, cfg Config) *river.Config {
 	maxWorkers := cfg.MaxWorkers
 	if maxWorkers <= 0 {
 		maxWorkers = 5
@@ -53,18 +64,19 @@ func NewClient(dbPool *pgxpool.Pool, workers *river.Workers, cfg Config) (*river
 	if fetchCooldown <= 0 {
 		fetchCooldown = 100 * time.Millisecond
 	}
+	fetchPollInterval := cfg.FetchPollInterval
+	if fetchPollInterval <= 0 {
+		fetchPollInterval = time.Second
+	}
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
+	return &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: maxWorkers},
 		},
-		Workers:       workers,
-		FetchCooldown: fetchCooldown,
-		PeriodicJobs:  cfg.PeriodicJobs,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("create river client: %w", err)
+		Workers:           workers,
+		FetchCooldown:     fetchCooldown,
+		FetchPollInterval: fetchPollInterval,
+		PollOnly:          cfg.PollOnly,
+		PeriodicJobs:      cfg.PeriodicJobs,
 	}
-
-	return riverClient, nil
 }

--- a/internal/platform/queue/river/client_integration_test.go
+++ b/internal/platform/queue/river/client_integration_test.go
@@ -2,6 +2,7 @@ package river
 
 import (
 	"context"
+	"errors"
 	"os"
 	"sync"
 	"testing"
@@ -36,6 +37,7 @@ func (w *testWorker) Work(ctx context.Context, job *river.Job[testJobArgs]) erro
 }
 
 func TestRiverClient_Integration(t *testing.T) {
+	// covers: AC-5, AC-7, AC-10
 	databaseURL := os.Getenv("TEST_DATABASE_URL")
 	if databaseURL == "" {
 		t.Skip("TEST_DATABASE_URL is not set")
@@ -44,7 +46,12 @@ func TestRiverClient_Integration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	pool, err := pgxpool.New(ctx, databaseURL)
+	poolConfig, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		t.Fatalf("parse pool config: %v", err)
+	}
+	poolConfig.ConnConfig.RuntimeParams["application_name"] = "paysplit-river-poll-integration"
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
 	if err != nil {
 		t.Fatalf("connect to database: %v", err)
 	}
@@ -61,7 +68,12 @@ func TestRiverClient_Integration(t *testing.T) {
 	river.AddWorker(workers, worker)
 
 	// 3. Create client
-	client, err := NewClient(pool, workers, Config{MaxWorkers: 2})
+	client, err := NewClient(pool, workers, Config{
+		MaxWorkers:        2,
+		FetchCooldown:     50 * time.Millisecond,
+		PollOnly:          true,
+		FetchPollInterval: 100 * time.Millisecond,
+	})
 	if err != nil {
 		t.Fatalf("NewClient failed: %v", err)
 	}
@@ -76,15 +88,40 @@ func TestRiverClient_Integration(t *testing.T) {
 		_ = client.Stop(stopCtx)
 	}()
 
+	var listenSessions int
+	if err = pool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM pg_stat_activity
+		WHERE application_name = 'paysplit-river-poll-integration'
+		  AND state = 'idle'
+		  AND query LIKE 'LISTEN %'
+	`).Scan(&listenSessions); err != nil {
+		t.Fatalf("count River LISTEN sessions: %v", err)
+	}
+	if listenSessions != 0 {
+		t.Fatalf("River poll-only LISTEN sessions = %d, want 0", listenSessions)
+	}
+
 	// 5. Enqueue job
-	_, err = client.Insert(ctx, testJobArgs{Message: "hello river"}, nil)
+	tx, err := pool.Begin(ctx)
 	if err != nil {
-		t.Fatalf("client.Insert failed: %v", err)
+		t.Fatalf("begin enqueue transaction: %v", err)
+	}
+	if _, err = client.InsertTx(ctx, tx, testJobArgs{Message: "hello river"}, nil); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("insert job in transaction: %v", err)
+	}
+	started := time.Now()
+	if err = tx.Commit(ctx); err != nil {
+		t.Fatalf("commit enqueue transaction: %v", err)
 	}
 
 	// 6. Wait for job to process
 	select {
 	case <-worker.doneCh:
+		if latency := time.Since(started); latency > 3*time.Second {
+			t.Fatalf("poll-only pickup latency = %s, want under test tolerance", latency)
+		}
 		worker.mu.Lock()
 		defer worker.mu.Unlock()
 		if len(worker.received) == 0 || worker.received[0] != "hello river" {
@@ -92,5 +129,143 @@ func TestRiverClient_Integration(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timed out waiting for river job to process")
+	}
+}
+
+type retryJobArgs struct {
+	Nonce string `json:"nonce"`
+}
+
+func (retryJobArgs) Kind() string { return "test_retry_job" }
+
+type retryWorker struct {
+	river.WorkerDefaults[retryJobArgs]
+	mu        sync.Mutex
+	attempts  int
+	succeeded chan struct{}
+}
+
+func (w *retryWorker) Work(_ context.Context, _ *river.Job[retryJobArgs]) error {
+	w.mu.Lock()
+	w.attempts++
+	attempts := w.attempts
+	w.mu.Unlock()
+	if attempts == 1 {
+		return errors.New("temporary failure")
+	}
+	select {
+	case w.succeeded <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+type periodicJobArgs struct {
+	Nonce string `json:"nonce"`
+}
+
+func (periodicJobArgs) Kind() string { return "test_periodic_job" }
+
+type periodicWorker struct {
+	river.WorkerDefaults[periodicJobArgs]
+	doneCh chan struct{}
+}
+
+func (w *periodicWorker) Work(_ context.Context, _ *river.Job[periodicJobArgs]) error {
+	select {
+	case w.doneCh <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func TestRiverClient_IntegrationScheduledRetryAndPeriodic(t *testing.T) {
+	// covers: AC-5, AC-7
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	poolConfig, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		t.Fatalf("parse pool config: %v", err)
+	}
+	poolConfig.ConnConfig.RuntimeParams["application_name"] = "paysplit-river-poll-jobs"
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		t.Fatalf("connect to database: %v", err)
+	}
+	defer pool.Close()
+
+	if err := AutoMigrate(ctx, pool); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	scheduledWorker := &testWorker{doneCh: make(chan struct{}, 1)}
+	retry := &retryWorker{succeeded: make(chan struct{}, 1)}
+	periodic := &periodicWorker{doneCh: make(chan struct{}, 1)}
+	workers := river.NewWorkers()
+	river.AddWorker(workers, scheduledWorker)
+	river.AddWorker(workers, retry)
+	river.AddWorker(workers, periodic)
+
+	client, err := NewClient(pool, workers, Config{
+		MaxWorkers:        2,
+		FetchCooldown:     50 * time.Millisecond,
+		PollOnly:          true,
+		FetchPollInterval: 100 * time.Millisecond,
+		PeriodicJobs: []*river.PeriodicJob{
+			river.NewPeriodicJob(river.PeriodicInterval(time.Hour), func() (river.JobArgs, *river.InsertOpts) {
+				return periodicJobArgs{Nonce: "start"}, nil
+			}, &river.PeriodicJobOpts{RunOnStart: true}),
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("client.Start failed: %v", err)
+	}
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		_ = client.Stop(stopCtx)
+	}()
+
+	scheduledAt := time.Now().Add(250 * time.Millisecond)
+	if _, err = client.Insert(ctx, testJobArgs{Message: "scheduled"}, &river.InsertOpts{ScheduledAt: scheduledAt}); err != nil {
+		t.Fatalf("insert scheduled job: %v", err)
+	}
+	select {
+	case <-scheduledWorker.doneCh:
+		if time.Now().Before(scheduledAt) {
+			t.Fatal("scheduled job ran before ScheduledAt")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for scheduled job")
+	}
+
+	if _, err = client.Insert(ctx, retryJobArgs{Nonce: "retry"}, &river.InsertOpts{MaxAttempts: 2}); err != nil {
+		t.Fatalf("insert retry job: %v", err)
+	}
+	select {
+	case <-retry.succeeded:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for retried job")
+	}
+	retry.mu.Lock()
+	attempts := retry.attempts
+	retry.mu.Unlock()
+	if attempts < 2 {
+		t.Fatalf("retry attempts = %d, want at least 2", attempts)
+	}
+
+	select {
+	case <-periodic.doneCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for periodic job")
 	}
 }

--- a/internal/platform/queue/river/client_test.go
+++ b/internal/platform/queue/river/client_test.go
@@ -3,6 +3,7 @@ package river
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/riverqueue/river"
 )
@@ -12,6 +13,46 @@ func TestNewClient_NilPool(t *testing.T) {
 	client, err := NewClient(nil, workers, Config{})
 	if err == nil {
 		t.Fatalf("expected error when pool is nil, got client: %v", client)
+	}
+}
+
+func TestClientConfigMapsPollOnlySettings(t *testing.T) {
+	workers := river.NewWorkers()
+	cfg := clientConfig(workers, Config{
+		MaxWorkers:        2,
+		FetchCooldown:     75 * time.Millisecond,
+		PollOnly:          true,
+		FetchPollInterval: 1500 * time.Millisecond,
+	})
+	if cfg.Workers != workers || !cfg.PollOnly {
+		t.Fatalf("poll only config was not mapped: %+v", cfg)
+	}
+	if cfg.FetchCooldown != 75*time.Millisecond || cfg.FetchPollInterval != 1500*time.Millisecond {
+		t.Fatalf("unexpected fetch intervals: cooldown=%s poll=%s", cfg.FetchCooldown, cfg.FetchPollInterval)
+	}
+	if cfg.Queues[river.QueueDefault].MaxWorkers != 2 {
+		t.Fatalf("max workers = %d, want 2", cfg.Queues[river.QueueDefault].MaxWorkers)
+	}
+}
+
+func TestClientConfigUsesSafeDefaults(t *testing.T) {
+	cfg := clientConfig(river.NewWorkers(), Config{})
+	if cfg.PollOnly || cfg.FetchCooldown != 100*time.Millisecond || cfg.FetchPollInterval != time.Second {
+		t.Fatalf("unexpected defaults: %+v", cfg)
+	}
+}
+
+func TestClientConfigMapsPeriodicJobs(t *testing.T) {
+	// covers: AC-5
+	workers := river.NewWorkers()
+	jobs := []*river.PeriodicJob{
+		river.NewPeriodicJob(river.PeriodicInterval(time.Hour), func() (river.JobArgs, *river.InsertOpts) {
+			return testJobArgs{Message: "periodic"}, nil
+		}, nil),
+	}
+	cfg := clientConfig(workers, Config{PeriodicJobs: jobs})
+	if len(cfg.PeriodicJobs) != 1 {
+		t.Fatalf("periodic jobs = %d, want 1", len(cfg.PeriodicJobs))
 	}
 }
 


### PR DESCRIPTION
## What

Each API process now uses one shared PostgreSQL listener for `bill_events` and `group_events` instead of two Hub loops. River can drop its notifier listener via `RIVER_POLL_ONLY` and pick up jobs by polling. Bill and Group SSE contracts stay the same.

## Why

Implements spec 0010 (`docs/specs/0010-connection-efficient-events/`). Long lived `LISTEN` sessions were three per instance (Bill, Group, River). This cuts application `LISTEN` sessions to one with poll only, or two when the River notifier stays on, and eases pressure on the pooler.

## Changes

- Platform `PostgresNotificationListener` owns one connection, listens on both channels, reconnects with backoff, and Destroy's a session that never finished `LISTEN` or failed `UNLISTEN *`.
- Bill and Group Hubs only decode, validate, and publish. Subscriber buffers stay 16 and 32. On listener drop, local SSE streams close so clients recover with snapshot and `/sync`.
- Graceful stop closes SSE first, then HTTP, River, the listener, then the pool. Listener and worker contexts are no longer children of the process signal context.
- `RIVER_POLL_ONLY` defaults to `false`. `RIVER_FETCH_POLL_INTERVAL_MS` defaults to 1000 and must be positive and at least `RIVER_FETCH_COOLDOWN_MS`.
- `DB_APPLICATION_NAME` is set on pool connections. Metrics `paysplit_db_listener_*` use allowlisted labels only.
- No schema or OpenAPI change.

## How to test / verify

- `go test ./internal/bootstrap ./internal/platform/database ./internal/platform/queue/river ./internal/config ./internal/modules/bill/delivery/http ./internal/modules/group/delivery/http`
- With `TEST_DATABASE_URL` set: `go test -count=1 -run Integration ./internal/platform/database ./internal/platform/queue/river`
- `go test ./...`
- Runtime: one process with a unique `DB_APPLICATION_NAME`, confirm one `LISTEN` session for Bill/Group; with `RIVER_POLL_ONLY=true` River has no `LISTEN`; `/health/ready` is 503 while the listener is down, then 200 after reconnect.

## Risk & rollout

Shared listener is one failure domain for both SSE types. Disconnect closes both streams on purpose. Two phase rollout: ship with `RIVER_POLL_ONLY=false` (notifier still on), then enable poll only per environment. River rollback is `RIVER_POLL_ONLY=false` and a process restart, no migration. Listener rollback is a revert; do not run old and new listeners in the same process.

## Notes for reviewers

Review `docs/reviews/2026-09-03-dev.md` flagged SIGTERM cancelling the listener before HTTP drain. That is fixed: SSE close runs first. Comment only edits in jwt, banks, and avatar processor were left out of this commit.